### PR TITLE
fix(security): detect IPv4-mapped IPv6 hex-word form in SSRF validation (closes #25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.5.1] — 2026-04-05
+
+### Fixed
+- **HIGH SSRF bypass**: `isPrivateIPv6` now detects IPv4-mapped IPv6 addresses in hex-word form (e.g. `::ffff:7f00:1`) that Node.js normalizes from dotted-decimal — previously only the dotted form (`::ffff:127.0.0.1`) was caught (closes #25)
+
 ## [1.5.0] — 2026-04-03
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -910,6 +910,14 @@ function isPrivateIPv6(addr: string): boolean {
     ];
     return isPrivateIPv4(octets);
   }
+  // IPv4-mapped IPv6 in hex-word form (::ffff:7f00:1) — Node normalizes to this
+  const v4MappedHex = normalized.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (v4MappedHex) {
+    const high = parseInt(v4MappedHex[1], 16);
+    const low = parseInt(v4MappedHex[2], 16);
+    const octets = [(high >> 8) & 0xff, high & 0xff, (low >> 8) & 0xff, low & 0xff];
+    return isPrivateIPv4(octets);
+  }
   return false;
 }
 


### PR DESCRIPTION
## What changed

`isPrivateIPv6` now detects IPv4-mapped IPv6 addresses in hex-word form (e.g. `::ffff:7f00:1`) that Node.js normalizes from dotted-decimal. Previously only the dotted form (`::ffff:127.0.0.1`) was caught, allowing SSRF bypass to loopback, RFC-1918, link-local, and cloud metadata addresses.

## Quality gates
- `npm run build` ✅

closes #25