### PR TITLE
fix(compat): align 5 tool schemas with platform contracts (closes #38, #41, #43, #46, #50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
 - Cap `retry-after` header to 60 seconds — prevents server-controlled indefinite hang DoS (closes #27)
 - Use explicit field allowlist in `update_strategy` route body instead of spread operator
 
+### Fixed
+- **BREAKING**: `ai_query` tool sends `question` instead of `query` to match platform `AiQueryDto`; added optional `context` field (closes #50)
+- **BREAKING**: `run_backtest` tool sends `dateRangeStart`/`dateRangeEnd`/`initialBalance` instead of `startDate`/`endDate`/`initialCapital` to match platform contract (closes #46)
+- **BREAKING**: `create_webhook` tool event values changed from SCREAMING_SNAKE_CASE to dot.notation to match platform (closes #43)
+- **BREAKING**: `create_strategy_from_description` tool sends `query` instead of `description` to match platform (closes #38)
+- **BREAKING**: `start_strategy` tool sends uppercase `"LIVE"`/`"PAPER"` mode values to match platform (closes #41)
+
 ## [1.5.0] — 2026-04-03
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ const createStrategySchema = z.object({
 });
 
 const createStrategyFromDescriptionSchema = z.object({
-  description: z.string().min(1).max(5000),
+  query: z.string().min(1).max(5000),
 });
 
 const createWebhookSchema = z.object({
@@ -29,7 +29,8 @@ const createWebhookSchema = z.object({
 });
 
 const aiQuerySchema = z.object({
-  query: z.string().min(1).max(5000),
+  question: z.string().min(1).max(5000),
+  context: z.string().max(5000).optional(),
 });
 
 const placeOrderSchema = z.object({
@@ -43,8 +44,9 @@ const placeOrderSchema = z.object({
 
 const runBacktestSchema = z.object({
   strategyId: z.string().uuid(),
-  startDate: z.string().optional(),
-  endDate: z.string().optional(),
+  dateRangeStart: z.string().optional(),
+  dateRangeEnd: z.string().optional(),
+  initialBalance: z.number().optional(),
 });
 
 const createAlertSchema = z.object({
@@ -205,10 +207,10 @@ const TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        description: { type: "string", description: "Natural language description of what the strategy should do (e.g. 'buy YES on Trump markets when price drops below 40 cents')" },
+        query: { type: "string", description: "Natural language description of what the strategy should do (e.g. 'buy YES on Trump markets when price drops below 40 cents')" },
         marketId: { type: "string", description: "Optional market ID to bind the strategy to" },
       },
-      required: ["description"],
+      required: ["query"],
     },
   },
   {
@@ -218,7 +220,7 @@ const TOOLS = [
       type: "object" as const,
       properties: {
         id: { type: "string", description: "Strategy UUID" },
-        mode: { type: "string", enum: ["live", "paper"], description: "Trading mode — paper is simulated, live places real orders (default: paper)" },
+        mode: { type: "string", enum: ["LIVE", "PAPER"], description: "Trading mode — PAPER is simulated, LIVE places real orders (default: PAPER)" },
       },
       required: ["id"],
     },
@@ -319,7 +321,7 @@ const TOOLS = [
         events: {
           type: "array",
           items: { type: "string" },
-          description: "Event types to subscribe to: ORDER_FILLED, STRATEGY_ERROR, WHALE_TRADE, NEWS_SIGNAL, BACKTEST_COMPLETE, DAILY_LOSS_LIMIT, MARKET_RESOLVED, PRICE_ALERT",
+          description: "Event types to subscribe to: order.filled, strategy.error, whale.trade, news.signal, backtest.complete, daily_loss.limit, market.resolved, price.alert",
         },
       },
       required: ["url", "events"],
@@ -331,9 +333,10 @@ const TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        query: { type: "string", description: "Natural language query (e.g. 'what are my best performing strategies this week?')" },
+        question: { type: "string", description: "Natural language question (e.g. 'what are my best performing strategies this week?')" },
+        context: { type: "string", description: "Optional additional context to include with the question" },
       },
-      required: ["query"],
+      required: ["question"],
     },
   },
   {
@@ -404,9 +407,9 @@ const TOOLS = [
       type: "object" as const,
       properties: {
         strategyId: { type: "string", description: "Strategy UUID to backtest" },
-        startDate: { type: "string", description: "ISO 8601 start date (e.g. 2024-01-01)" },
-        endDate: { type: "string", description: "ISO 8601 end date (e.g. 2024-12-31)" },
-        initialCapital: { type: "number", description: "Starting USDC capital (default 1000)" },
+        dateRangeStart: { type: "string", description: "ISO 8601 start date (e.g. 2024-01-01)" },
+        dateRangeEnd: { type: "string", description: "ISO 8601 end date (e.g. 2024-12-31)" },
+        initialBalance: { type: "number", description: "Starting USDC capital (default 1000)" },
       },
       required: ["strategyId"],
     },


### PR DESCRIPTION
## What changed

Aligned 5 MCP tool Zod schemas and inputSchema definitions with platform API contracts:

- **ai_query** (#50): `query` → `question`, added optional `context` field
- **run_backtest** (#46): `startDate`/`endDate` → `dateRangeStart`/`dateRangeEnd`, `initialCapital` → `initialBalance`
- **create_webhook** (#43): SCREAMING_SNAKE_CASE events → dot.notation
- **create_strategy_from_description** (#38): `description` → `query`
- **start_strategy** (#41): lowercase mode → uppercase LIVE/PAPER

## Quality gates
- `npm run build` ✅

closes #38, closes #41, closes #43, closes #46, closes #50