### PR TITLE
fix(security): remove .passthrough(), add missing Zod schemas, cap retry-after (closes #26, #27, #28, #37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Security
 - **CI**: switch from self-hosted runner to `ubuntu-latest` for `pull_request` events and add `permissions: contents: read` to restrict GITHUB_TOKEN scope (closes #69)
 - **SSRF**: add hex-word IPv4-mapped IPv6 pattern matching (`::ffff:7f00:1` form) to `isPrivateIPv6()` — prevents bypass of webhook URL validation via Node.js-normalized addresses (closes #25)
+- Remove `.passthrough()` from `updateStrategySchema` — prevents mass-assignment of arbitrary fields to `PATCH /strategies/:id` (closes #26, closes #37)
+- Add `provideLiquiditySchema` Zod validation — enforces UUID tokenId, positive spread ≤1, positive size before forwarding to `/lp/provide` (closes #28)
+- Add `startStrategySchema` Zod validation — enforces enum mode (`live`|`paper`) before forwarding to `/strategies/:id/start` (closes #28)
+- Cap `retry-after` header to 60 seconds — prevents server-controlled indefinite hang DoS (closes #27)
+- Use explicit field allowlist in `update_strategy` route body instead of spread operator
 
 ## [1.5.0] — 2026-04-03
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ const updateStrategySchema = z.object({
   name: z.string().min(1).max(200).optional(),
   description: z.string().max(2000).optional(),
   marketId: z.string().optional(),
-}).passthrough();
+});
 
 const closePositionSchema = z.object({
   tokenId: z.string().uuid(),
@@ -79,6 +79,17 @@ const splitPositionSchema = z.object({
 
 const mergePositionSchema = z.object({
   tokenIds: z.array(z.string().uuid()).min(2),
+});
+
+const provideLiquiditySchema = z.object({
+  tokenId: z.string().uuid(),
+  spread: z.number().positive().max(1),
+  size: z.number().positive(),
+});
+
+const startStrategySchema = z.object({
+  id: z.string().uuid(),
+  mode: z.enum(["live", "paper"]).default("paper"),
 });
 
 const importStrategySchema = z.object({
@@ -720,9 +731,9 @@ const ROUTES: Record<string, RouteConfig> = {
   list_strategies: { method: "GET", path: "/api/v1/strategies", query: (a) => pickDefined(a, ["status"]) },
   get_strategy: { method: "GET", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}` },
   create_strategy: { method: "POST", path: "/api/v1/strategies", body: (a) => createStrategySchema.parse(a) },
-  update_strategy: { method: "PATCH", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}`, body: (a) => { const { id: _id, ...rest } = updateStrategySchema.parse(a); return rest; } },
+  update_strategy: { method: "PATCH", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}`, body: (a) => { const parsed = updateStrategySchema.parse(a); return pickDefined(parsed as Record<string, unknown>, ["name", "description", "marketId"]); } },
   create_strategy_from_description: { method: "POST", path: "/api/v1/strategies/from-description", body: (a) => createStrategyFromDescriptionSchema.parse(a) },
-  start_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/start`, body: (a) => ({ mode: a.mode ?? "paper" }) },
+  start_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/start`, body: (a) => { const parsed = startStrategySchema.parse(a); return { mode: parsed.mode }; } },
   stop_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/stop` },
   get_strategy_templates: { method: "GET", path: "/api/v1/strategies/templates" },
   export_strategy: { method: "GET", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/export` },
@@ -734,7 +745,7 @@ const ROUTES: Record<string, RouteConfig> = {
   get_accuracy: { method: "GET", path: "/api/v1/accuracy/me" },
   get_portfolio_review: { method: "GET", path: "/api/v1/ai/portfolio-review" },
   get_market_sentiment: { method: "GET", path: (a) => `/api/v1/news/sentiment/${encodeURIComponent(String(a.marketId))}` },
-  provide_liquidity: { method: "POST", path: "/api/v1/lp/provide", body: (a) => ({ tokenId: a.tokenId, spread: a.spread, size: a.size }) },
+  provide_liquidity: { method: "POST", path: "/api/v1/lp/provide", body: (a) => provideLiquiditySchema.parse(a) },
   list_alerts: { method: "GET", path: "/api/v1/alerts" },
   list_copy_configs: { method: "GET", path: "/api/v1/copy" },
   list_webhooks: { method: "GET", path: "/api/v1/webhooks" },
@@ -1143,7 +1154,7 @@ async function callApi(
     });
 
     if (res.status === 429 && attempt < MAX_RETRIES) {
-      const retryAfter = Number(res.headers.get("retry-after") || "0");
+      const retryAfter = Math.min(Number(res.headers.get("retry-after") || "0"), 60);
       const backoffMs = retryAfter > 0 ? retryAfter * 1000 : Math.min(1000 * 2 ** attempt, 8000);
       await new Promise((r) => setTimeout(r, backoffMs));
       continue;


### PR DESCRIPTION
## What changed\n\n### Remove `.passthrough()` from `updateStrategySchema` (closes #26, closes #37)\n\nThe `updateStrategySchema` still had `.passthrough()` — a regression of #9. Any extra fields sent by an MCP client were forwarded unmodified to `PATCH /api/v1/strategies/:id`, enabling mass-assignment of arbitrary fields like `ownerId`, `isPublic`, `status`.\n\n**Fix:** Removed `.passthrough()` and replaced the spread-based body extractor (`{ id: _id, ...rest }`) with an explicit `pickDefined()` allowlist for `name`, `description`, `marketId` only.\n\n### Add Zod validation for `provide_liquidity` and `start_strategy` (closes #28)\n\nTwo financial handlers passed user input to the backend without Zod schema validation:\n- `provide_liquidity`: no UUID check on `tokenId`, no range check on `spread` (could be negative/zero/>1), no positivity check on `size`\n- `start_strategy`: `mode` field passed without enum validation\n\n**Fix:** Added `provideLiquiditySchema` (UUID tokenId, positive spread ≤1, positive size) and `startStrategySchema` (enum mode with `paper` default).\n\n### Cap `retry-after` header to 60 seconds (closes #27)\n\nThe `callApi` retry logic read the `retry-after` header without any upper bound. A malicious or misconfigured server returning `retry-after: 999999` would block the MCP request handler for ~278 hours, permanently stalling the server.\n\n**Fix:** `Math.min(Number(res.headers.get(\"retry-after\") || \"0\"), 60)`\n\n## Quality gates\n- `npm run build` — verified locally via patch script\n- CHANGELOG.md updated\n\ncloses #26, closes #27, closes #28, closes #37