### PR TITLE
fix(ci): switch to GitHub-hosted runners to prevent fork code execution (closes #69)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,13 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Build
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.5.1] — 2026-04-08
+
+### Security
+- Switch CI from self-hosted to GitHub-hosted runners (`ubuntu-latest`) and add `permissions: contents: read` to prevent arbitrary code execution from fork PRs (closes #69)
+
 ## [1.5.0] — 2026-04-03
 
 ### Added


### PR DESCRIPTION
## What changed

Switched CI from self-hosted to GitHub-hosted runners (ubuntu-latest) and added permissions: contents: read to prevent arbitrary code execution from untrusted fork PRs.

closes #69