### PR TITLE
fix(security): use ubuntu-latest runners and block IPv6 hex SSRF bypass (closes #25, closes #69)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,13 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Build
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+- **CI**: switch from self-hosted runner to `ubuntu-latest` for `pull_request` events and add `permissions: contents: read` to restrict GITHUB_TOKEN scope (closes #69)
+- **SSRF**: add hex-word IPv4-mapped IPv6 pattern matching (`::ffff:7f00:1` form) to `isPrivateIPv6()` — prevents bypass of webhook URL validation via Node.js-normalized addresses (closes #25)
+
 ## [1.5.0] — 2026-04-03
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -899,7 +899,7 @@ function isPrivateIPv6(addr: string): boolean {
   if (normalized.startsWith("fe80:") || normalized.startsWith("fe80")) return true;
   // Unique local (fc00::/7 — fc00::/8 and fd00::/8)
   if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true;
-  // IPv4-mapped IPv6 (::ffff:x.x.x.x) — check the embedded IPv4
+  // IPv4-mapped IPv6 (::ffff:x.x.x.x) — check the embedded IPv4 (dotted-decimal form)
   const v4MappedMatch = normalized.match(/^::ffff:(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
   if (v4MappedMatch) {
     const octets = [
@@ -908,6 +908,14 @@ function isPrivateIPv6(addr: string): boolean {
       parseInt(v4MappedMatch[3], 10),
       parseInt(v4MappedMatch[4], 10),
     ];
+    return isPrivateIPv4(octets);
+  }
+  // IPv4-mapped IPv6 hex-word form (::ffff:7f00:1) — Node.js normalizes to this
+  const v4MappedHex = normalized.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (v4MappedHex) {
+    const high = parseInt(v4MappedHex[1], 16);
+    const low = parseInt(v4MappedHex[2], 16);
+    const octets = [(high >> 8) & 0xff, high & 0xff, (low >> 8) & 0xff, low & 0xff];
     return isPrivateIPv4(octets);
   }
   return false;


### PR DESCRIPTION
## What changed
- Switch CI from self-hosted runner to ubuntu-latest for pull_request events
- Add permissions: contents: read to restrict GITHUB_TOKEN
- Add hex-word IPv4-mapped IPv6 detection in isPrivateIPv6() to prevent SSRF bypass

closes #25
closes #69