### PR TITLE
fix(security): validate import schema and fix hono CVEs (closes #70, closes #72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Security
+- **Import validation**: Replace open `z.record(z.string(), z.unknown())` in `importStrategySchema` with concrete schema matching backend `ImportStrategyDto` — validates name, description, execMode, blocks, variables, canvas with type constraints and size limits; unwrap `data` wrapper so backend receives correct shape; rejects prototype pollution payloads at MCP boundary (closes #70)
+- **Dependencies**: Override `hono` to >=4.12.12 and `@hono/node-server` to >=1.19.13 — fixes 6 CVEs (cookie bypass CVE-2026-39410, path traversal CVE-2026-39408, middleware bypass CVE-2026-39407, header injection GHSA-26pp-8wgv-hjvm) in transitive deps from `@modelcontextprotocol/sdk` (closes #72)
 - **Input validation**: Add UUID format validation to all 15 ID-accepting tools (`get_market`, `get_strategy`, `cancel_order`, `delete_alert`, `get_backtest`, `export_strategy`, `stop_strategy`, `pause_strategy`, `resume_strategy`, `fork_strategy`, `delete_strategy`, `purchase_strategy`, `cancel_smart_order`, `get_marketplace_listing`, `get_market_sentiment`) — malformed IDs are rejected at the MCP boundary instead of forwarded to the backend (closes #48)
 - **Query validation**: Add Zod schemas with bounded limits (max 100), typed numerics, and enum constraints to all 11 query-parameter tools (`list_markets`, `get_orders`, `list_backtests`, `get_whale_feed`, `get_news_signals`, `browse_marketplace`, `get_portfolio_pnl`, `list_conditional_orders`, `get_arbitrage_opportunities`, `list_strategies`, `list_smart_orders`) — prevents unbounded limit DoS and type confusion (closes #49)
 - **CI**: switch from self-hosted runner to `ubuntu-latest` for `pull_request` events and add `permissions: contents: read` to restrict GITHUB_TOKEN scope (closes #69)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,10 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
       },
@@ -549,9 +550,10 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -43,5 +43,9 @@
   },
   "engines": {
     "node": ">=20.0.0"
+  },
+  "overrides": {
+    "hono": ">=4.12.12",
+    "@hono/node-server": ">=1.19.13"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,8 +93,38 @@ const startStrategySchema = z.object({
   mode: z.enum(["live", "paper"]).default("paper"),
 });
 
+const importBlockSchema = z.object({
+  type: z.string().max(100),
+  config: z.record(z.string(), z.unknown()).optional(),
+});
+
 const importStrategySchema = z.object({
-  data: z.record(z.string(), z.unknown()),
+  data: z.object({
+    polyforge: z.string().max(20),
+    exportedAt: z.string().max(50).optional(),
+    strategy: z.object({
+      name: z.string().min(1).max(100),
+      description: z.string().max(500).optional(),
+      execMode: z.enum(["TICK", "EVENT", "HYBRID"]).optional(),
+      tickMs: z.number().int().min(200).max(60000).optional(),
+      visibility: z.enum(["PRIVATE", "PUBLIC", "UNLISTED"]).optional(),
+      tags: z.array(z.string().max(50)).max(20).optional(),
+      variables: z.array(z.object({
+        name: z.string().max(50).regex(/^[a-zA-Z_][a-zA-Z0-9_]*$/),
+        expression: z.string().max(200),
+      })).max(20).optional(),
+      blocks: z.object({
+        safety: z.array(importBlockSchema).max(20).optional(),
+        triggers: z.array(importBlockSchema).max(50).optional(),
+        conditions: z.array(importBlockSchema).max(50).optional(),
+        actions: z.array(importBlockSchema).max(50).optional(),
+      }).optional(),
+      canvas: z.object({
+        positions: z.record(z.string(), z.object({ x: z.number(), y: z.number() })).optional(),
+        connections: z.array(z.object({ from: z.string(), to: z.string() })).optional(),
+      }).optional(),
+    }),
+  }),
 });
 
 const createConditionalOrderSchema = z.object({
@@ -730,11 +760,23 @@ const TOOLS = [
   },
   {
     name: "import_strategy",
-    description: "Import a strategy from a .polyforge JSON export file. Creates a new strategy in your account.",
+    description: "Import a strategy from a .polyforge JSON export file. Creates a new strategy in your account. The 'data' field must be the full .polyforge export object with polyforge version, optional exportedAt, and a strategy object.",
     inputSchema: {
       type: "object" as const,
       properties: {
-        data: { type: "object", description: "Strategy export JSON data (from export_strategy)" },
+        data: {
+          type: "object",
+          description: "The .polyforge export object containing polyforge (version string), optional exportedAt, and strategy (with name, description, execMode, blocks, variables, canvas, etc.)",
+          properties: {
+            polyforge: { type: "string", description: "Export format version" },
+            exportedAt: { type: "string", description: "ISO timestamp of export" },
+            strategy: {
+              type: "object",
+              description: "Strategy definition with name, description, execMode, tickMs, visibility, tags, variables, blocks, and canvas",
+            },
+          },
+          required: ["polyforge", "strategy"],
+        },
       },
       required: ["data"],
     },
@@ -851,7 +893,7 @@ const ROUTES: Record<string, RouteConfig> = {
   resume_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/resume`, schema: idSchema },
   fork_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/fork`, schema: idSchema },
   delete_strategy: { method: "DELETE", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}`, schema: idSchema },
-  import_strategy: { method: "POST", path: "/api/v1/strategies/import", body: (a) => importStrategySchema.parse(a) },
+  import_strategy: { method: "POST", path: "/api/v1/strategies/import", body: (a) => importStrategySchema.parse(a).data },
   // Trading tools (closes #15)
   redeem_position: { method: "POST", path: "/api/v1/orders/redeem", body: (a) => redeemPositionSchema.parse(a) },
   split_position: { method: "POST", path: "/api/v1/orders/split", body: (a) => splitPositionSchema.parse(a) },


### PR DESCRIPTION
## Summary

- **#70 — Import schema mass assignment**: Replaced open `z.record(z.string(), z.unknown())` in `importStrategySchema` with concrete Zod schema matching backend `ImportStrategyDto`. Validates strategy name, description, execMode, tickMs, visibility, tags, variables, blocks (with array size limits), and canvas. Also fixes the body function to unwrap the `data` wrapper so the backend receives the correct DTO shape.
- **#72 — Hono CVEs**: Added npm overrides for `hono` (>=4.12.12) and `@hono/node-server` (>=1.19.13) to fix 6 CVEs (cookie prefix bypass, path traversal, middleware bypass, header injection) in transitive deps from `@modelcontextprotocol/sdk`.

## Test plan

- [x] `npm run build` passes (TypeScript compiles)
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm ls hono @hono/node-server` shows patched versions (4.12.12, 1.19.13)
- [ ] CI passes

closes #70, closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)