### PR TITLE
fix(schemas): align Zod schemas with platform API contract (closes #58, closes #59, closes #52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+- **BREAKING**: `close_position` Zod schema used `outcome` (enum YES/NO) instead of `size` (number) — partial close requests silently lost the size parameter, potentially closing entire positions instead of the requested amount (closes #58)
+- **BREAKING**: `create_strategy` Zod schema used `tokenId` instead of `marketId` — market binding was silently stripped; also removed phantom `rules` field not in platform contract (closes #59)
+- **BREAKING**: `create_conditional_order` Zod schema missing `marketId` and `type` fields (stripped by Zod, causing 422 errors); `price` renamed to `limitPrice` to match platform DTO; `triggerPrice` made required; added all 5 conditional order types (`TAKE_PROFIT`, `STOP_LOSS`, `TRAILING_STOP`, `LIMIT`, `PEGGED`) instead of only 2; added `trailingPct` and `expiresAt` optional fields (closes #52)
+
 ### Security
 - **DNS rebinding SSRF mitigation**: `validateWebhookUrl()` now resolves domain names via `dns.resolve4()`/`dns.resolve6()` and checks all resolved IPs against the private IP blocklist, preventing SSRF bypass via attacker-controlled DNS records; also handles decimal/octal-encoded IPs via URL parsing normalization; documents that this is a client-side best-effort check and the server must independently validate (closes #35)
 - **Import validation**: Replace open `z.record(z.string(), z.unknown())` in `importStrategySchema` with concrete schema matching backend `ImportStrategyDto` — validates name, description, execMode, blocks, variables, canvas with type constraints and size limits; unwrap `data` wrapper so backend receives correct shape; rejects prototype pollution payloads at MCP boundary (closes #70)

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,7 @@ import { isIP } from "node:net";
 const createStrategySchema = z.object({
   name: z.string().min(1).max(200),
   description: z.string().max(2000).optional(),
-  tokenId: z.string().uuid().optional(),
-  rules: z.array(z.record(z.string(), z.unknown())).optional(),
+  marketId: z.string().optional(),
 });
 
 const createStrategyFromDescriptionSchema = z.object({
@@ -66,7 +65,7 @@ const updateStrategySchema = z.object({
 
 const closePositionSchema = z.object({
   tokenId: z.string().uuid(),
-  outcome: z.enum(["YES", "NO"]).optional(),
+  size: z.number().positive().optional(),
 });
 
 const redeemPositionSchema = z.object({
@@ -130,12 +129,16 @@ const importStrategySchema = z.object({
 });
 
 const createConditionalOrderSchema = z.object({
+  marketId: z.string(),
   tokenId: z.string().uuid(),
+  type: z.enum(["TAKE_PROFIT", "STOP_LOSS", "TRAILING_STOP", "LIMIT", "PEGGED"]),
   side: z.enum(["BUY", "SELL"]),
   outcome: z.enum(["YES", "NO"]),
   size: z.number().positive().int().min(1),
-  price: z.number().min(0.001).max(0.999),
-  triggerPrice: z.number().min(0).max(1).optional(),
+  triggerPrice: z.number().min(0).max(1),
+  limitPrice: z.number().min(0.001).max(0.999).optional(),
+  trailingPct: z.string().optional(),
+  expiresAt: z.string().optional(),
 });
 
 const placeSmartOrderSchema = z.object({
@@ -570,17 +573,20 @@ const TOOLS = [
   },
   {
     name: "create_conditional_order",
-    description: "Create a take-profit or stop-loss conditional order that triggers automatically when the market price reaches your threshold.",
+    description: "Create a conditional order that triggers automatically when the market price reaches your threshold.",
     inputSchema: {
       type: "object" as const,
       properties: {
         marketId: { type: "string", description: "Market UUID" },
         tokenId: { type: "string", description: "Token ID to trade when triggered" },
-        type: { type: "string", enum: ["TAKE_PROFIT", "STOP_LOSS"], description: "Conditional order type" },
+        type: { type: "string", enum: ["TAKE_PROFIT", "STOP_LOSS", "TRAILING_STOP", "LIMIT", "PEGGED"], description: "Conditional order type" },
         side: { type: "string", enum: ["BUY", "SELL"], description: "Order side when triggered" },
         outcome: { type: "string", enum: ["YES", "NO"], description: "Market outcome" },
-        size: { type: "string", description: "Number of shares" },
-        triggerPrice: { type: "string", description: "Price that triggers the order (0.001-0.999)" },
+        size: { type: "number", description: "Number of shares" },
+        triggerPrice: { type: "number", description: "Price that triggers the order (0-1)" },
+        limitPrice: { type: "number", description: "Limit price for the order (0.001-0.999, optional)" },
+        trailingPct: { type: "string", description: "Trailing percentage for TRAILING_STOP orders" },
+        expiresAt: { type: "string", description: "Expiry timestamp (ISO 8601)" },
       },
       required: ["marketId", "tokenId", "type", "side", "outcome", "size", "triggerPrice"],
     },


### PR DESCRIPTION
## Summary

Three critical Zod schema mismatches caused silent data loss or 422 failures:

- **`close_position` (#58):** Schema had `outcome` (YES/NO enum) instead of `size` (number). Partial close requests silently lost the size parameter — the platform could close the entire position instead of the requested amount.
- **`create_strategy` (#59):** Schema had `tokenId` instead of `marketId`. Market binding was silently stripped by Zod parse. Also removed phantom `rules` field not in platform contract.
- **`create_conditional_order` (#52):** Schema was missing `marketId` and `type` (both stripped by Zod → 422 from backend). Renamed `price` to `limitPrice`, made `triggerPrice` required, expanded type enum from 2 to all 5 platform values, added `trailingPct` and `expiresAt` optional fields.

## Test plan

- [ ] Verify `tsc` builds cleanly (no type errors)
- [ ] Verify `close_position` with `size` parameter correctly forwards to backend
- [ ] Verify `create_strategy` with `marketId` correctly forwards to backend
- [ ] Verify `create_conditional_order` with all required fields accepts all 5 order types

closes #58, closes #59, closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)