### PR TITLE
fix(compat): correct 4 breaking request payload regressions (closes #85, #86, #87, #88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.6.8] — 2026-04-13
+
+### Fixed
+- **BREAKING** `ai_query`: Zod schema and tool input use `query` instead of `question` to match platform `AiQueryDto` — AI queries were returning HTTP 400 (closes #85, regression of #50)
+- **BREAKING** `create_strategy_from_description`: Zod schema and tool input use `description` instead of `query` to match platform `CreateFromDescriptionDto` — AI strategy creation was returning HTTP 400 (closes #86, regression of #38)
+- **BREAKING** `create_webhook`: tool description now lists SCREAMING_SNAKE_CASE event names (`ORDER_FILLED` etc.) to match platform validation (closes #87, regression of #43)
+- **BREAKING** `start_strategy`: tool input enum uses lowercase `"live"`/`"paper"` instead of uppercase to match platform `StartStrategyDto` (closes #88, regression of #41)
+
 ## [Unreleased]
 
 ### Security

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ const createStrategySchema = z.object({
 });
 
 const createStrategyFromDescriptionSchema = z.object({
-  query: z.string().min(1).max(5000),
+  description: z.string().min(1).max(5000),
 });
 
 const createWebhookSchema = z.object({
@@ -29,7 +29,7 @@ const createWebhookSchema = z.object({
 });
 
 const aiQuerySchema = z.object({
-  question: z.string().min(1).max(5000),
+  query: z.string().min(1).max(5000),
   context: z.string().max(5000).optional(),
 });
 
@@ -316,10 +316,10 @@ const TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        query: { type: "string", description: "Natural language description of what the strategy should do (e.g. 'buy YES on Trump markets when price drops below 40 cents')" },
+        description: { type: "string", description: "Natural language description of what the strategy should do (e.g. 'buy YES on Trump markets when price drops below 40 cents')" },
         marketId: { type: "string", description: "Optional market ID to bind the strategy to" },
       },
-      required: ["query"],
+      required: ["description"],
     },
   },
   {
@@ -329,7 +329,7 @@ const TOOLS = [
       type: "object" as const,
       properties: {
         id: { type: "string", description: "Strategy UUID" },
-        mode: { type: "string", enum: ["LIVE", "PAPER"], description: "Trading mode — PAPER is simulated, LIVE places real orders (default: PAPER)" },
+        mode: { type: "string", enum: ["live", "paper"], description: "Trading mode — paper is simulated, live places real orders (default: paper)" },
       },
       required: ["id"],
     },
@@ -430,7 +430,7 @@ const TOOLS = [
         events: {
           type: "array",
           items: { type: "string" },
-          description: "Event types to subscribe to: order.filled, strategy.error, whale.trade, news.signal, backtest.complete, daily_loss.limit, market.resolved, price.alert",
+          description: "Event types to subscribe to: ORDER_FILLED, STRATEGY_ERROR, WHALE_TRADE, NEWS_SIGNAL, BACKTEST_COMPLETE, DAILY_LOSS_LIMIT, MARKET_RESOLVED, PRICE_ALERT",
         },
       },
       required: ["url", "events"],
@@ -442,10 +442,10 @@ const TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        question: { type: "string", description: "Natural language question (e.g. 'what are my best performing strategies this week?')" },
-        context: { type: "string", description: "Optional additional context to include with the question" },
+        query: { type: "string", description: "Natural language question (e.g. 'what are my best performing strategies this week?')" },
+        context: { type: "string", description: "Optional additional context to include with the query" },
       },
-      required: ["question"],
+      required: ["query"],
     },
   },
   {


### PR DESCRIPTION
## Problem

Four breaking compat regressions caused every call to `ai_query`, `create_strategy_from_description`, `create_webhook`, and `start_strategy` MCP tools to produce HTTP 400 errors.

## What changed

| Tool | Before (broken) | After (correct) | Issue |
|------|-----------------|------------------|-------|
| `ai_query` | `{ "question": ... }` | `{ "query": ... }` | closes #85 |
| `create_strategy_from_description` | `{ "query": ... }` | `{ "description": ... }` | closes #86 |
| `create_webhook` events description | `order.filled` (dot.notation) | `ORDER_FILLED` (SCREAMING_SNAKE) | closes #87 |
| `start_strategy` mode enum | `"LIVE"` / `"PAPER"` | `"live"` / `"paper"` | closes #88 |

Updated both Zod schemas (internal validation) and MCP tool input schemas (LLM-facing).

Typecheck and build clean.

closes #85, closes #86, closes #87, closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)