### PR TITLE
fix(compat): fix 7 breaking Zod schemas and tool definitions (closes #21, #22, #23, #24, #30, #36, #60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.7.0] — 2026-04-13
+
+### Fixed
+- **BREAKING** `create_strategy_from_description`: Zod schema silently stripped `marketId` — AI-generated strategies could not be bound to a market (closes #60)
+- **BREAKING** `run_backtest`: removed phantom `initialBalance` field not in platform contract; added `quickMode`, `strategyBlocks`, `marketBindings` optional fields to match platform DTO (closes #23)
+- **BREAKING** `create_conditional_order`: removed `tokenId`, `outcome`, `type`, `trailingPct`, `expiresAt` fields not in platform contract; schema now matches platform: `{ marketId, side, size, triggerPrice, limitPrice? }` (closes #24)
+- **BREAKING** `close_position`: `size` field changed from `z.number()` to `z.string()` to match platform NumberString format for partial closes (closes #30)
+- **BREAKING** `place_order`, `place_smart_order`: removed `.int()` restriction on size/totalSize — platform accepts decimal share amounts (closes #36)
+- Tool definitions (inputSchema) updated to match all schema changes above
+
 ## [1.6.9] — 2026-04-13
 
 ### Fixed

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ const createStrategySchema = z.object({
 
 const createStrategyFromDescriptionSchema = z.object({
   description: z.string().min(1).max(5000),
+  marketId: z.string().optional(),
 });
 
 const createWebhookSchema = z.object({
@@ -37,7 +38,7 @@ const placeOrderSchema = z.object({
   tokenId: z.string().uuid(),
   side: z.enum(["BUY", "SELL"]),
   outcome: z.enum(["YES", "NO"]),
-  size: z.number().positive().int().min(1),
+  size: z.number().positive().min(1),
   price: z.number().min(0.001).max(0.999),
   orderType: z.enum(["GTC", "GTD", "FOK"]).optional(),
 });
@@ -46,7 +47,9 @@ const runBacktestSchema = z.object({
   strategyId: z.string().uuid(),
   dateRangeStart: z.string().optional(),
   dateRangeEnd: z.string().optional(),
-  initialBalance: z.number().positive().optional(),
+  quickMode: z.boolean().optional(),
+  strategyBlocks: z.unknown().optional(),
+  marketBindings: z.unknown().optional(),
 });
 
 const createAlertSchema = z.object({
@@ -65,7 +68,7 @@ const updateStrategySchema = z.object({
 
 const closePositionSchema = z.object({
   tokenId: z.string().uuid(),
-  size: z.number().positive().optional(),
+  size: z.string().optional(),
 });
 
 const redeemPositionSchema = z.object({
@@ -127,15 +130,10 @@ const importStrategySchema = z.object({
 
 const createConditionalOrderSchema = z.object({
   marketId: z.string(),
-  tokenId: z.string().uuid(),
-  type: z.enum(["TAKE_PROFIT", "STOP_LOSS", "TRAILING_STOP", "LIMIT", "PEGGED"]),
   side: z.enum(["BUY", "SELL"]),
-  outcome: z.enum(["YES", "NO"]),
-  size: z.number().positive().int().min(1),
+  size: z.number().positive(),
   triggerPrice: z.number().min(0).max(1),
   limitPrice: z.number().min(0.001).max(0.999).optional(),
-  trailingPct: z.string().optional(),
-  expiresAt: z.string().optional(),
 });
 
 const placeSmartOrderSchema = z.object({
@@ -143,7 +141,7 @@ const placeSmartOrderSchema = z.object({
   tokenId: z.string().uuid(),
   side: z.enum(["BUY", "SELL"]),
   outcome: z.enum(["YES", "NO"]),
-  totalSize: z.number().positive().int().min(1),
+  totalSize: z.number().positive().min(1),
   slices: z.number().int().min(2).max(100).optional(),
   intervalMinutes: z.number().int().min(1).max(10080).optional(),
   limitPrice: z.number().min(0.001).max(0.999).optional(),
@@ -515,7 +513,9 @@ const TOOLS = [
         strategyId: { type: "string", description: "Strategy UUID to backtest" },
         dateRangeStart: { type: "string", description: "ISO 8601 start date (e.g. 2024-01-01)" },
         dateRangeEnd: { type: "string", description: "ISO 8601 end date (e.g. 2024-12-31)" },
-        initialBalance: { type: "number", description: "Starting USDC balance (default 1000)" },
+        quickMode: { type: "boolean", description: "If true, run a faster approximate backtest (optional)" },
+        strategyBlocks: { type: "object", description: "Override strategy block configuration for the backtest (optional)" },
+        marketBindings: { type: "object", description: "Override market bindings for the backtest (optional)" },
       },
       required: ["strategyId"],
     },
@@ -575,17 +575,12 @@ const TOOLS = [
       type: "object" as const,
       properties: {
         marketId: { type: "string", description: "Market UUID" },
-        tokenId: { type: "string", description: "Token ID to trade when triggered" },
-        type: { type: "string", enum: ["TAKE_PROFIT", "STOP_LOSS", "TRAILING_STOP", "LIMIT", "PEGGED"], description: "Conditional order type" },
         side: { type: "string", enum: ["BUY", "SELL"], description: "Order side when triggered" },
-        outcome: { type: "string", enum: ["YES", "NO"], description: "Market outcome" },
-        size: { type: "number", description: "Number of shares" },
+        size: { type: "number", description: "Number of shares (decimals accepted)" },
         triggerPrice: { type: "number", description: "Price that triggers the order (0-1)" },
         limitPrice: { type: "number", description: "Limit price for the order (0.001-0.999, optional)" },
-        trailingPct: { type: "string", description: "Trailing percentage for TRAILING_STOP orders" },
-        expiresAt: { type: "string", description: "Expiry timestamp (ISO 8601)" },
       },
-      required: ["marketId", "tokenId", "type", "side", "outcome", "size", "triggerPrice"],
+      required: ["marketId", "side", "size", "triggerPrice"],
     },
   },
   {


### PR DESCRIPTION
## Summary
- **create_strategy** (#21): `tokenId` → `marketId`, remove spurious `rules` field — already fixed in prior commit, issue can close
- **create_alert** (#22): `type`/`threshold` → `direction`/`price`, add `persistent`, fix casing — already fixed in prior commit, issue can close
- **run_backtest** (#23): remove phantom `initialBalance` field; add `quickMode`, `strategyBlocks`, `marketBindings` optional fields to match platform DTO
- **create_conditional_order** (#24): rewrite schema to platform contract `{ marketId, side, size, triggerPrice, limitPrice? }` — removed `tokenId`, `outcome`, `type`, `trailingPct`, `expiresAt`
- **close_position** (#30): `size` field changed from `z.number()` to `z.string()` to match platform NumberString format
- **place_order** + **place_smart_order** (#36): removed `.int()` restriction on size — platform accepts decimal share amounts
- **create_strategy_from_description** (#60): added `marketId` to Zod schema so it's no longer stripped by `.parse()`

## Test plan
- [ ] All Zod schemas validate correct platform payloads
- [ ] Tool definitions (inputSchema) match schema changes
- [ ] Handler code uses correct field names
- [ ] TypeScript build succeeds (`npx tsc --noEmit` passes)
- [ ] CHANGELOG updated

closes #21, closes #22, closes #23, closes #24, closes #30, closes #36, closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)