### PR TITLE
fix(tools): add watchlist CRUD and webhook delete/test tools (closes #54, closes #57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - `add_to_watchlist` tool — add a market to the watchlist (closes #54)
 - `remove_from_watchlist` tool — remove a market from the watchlist (closes #54)
 - `get_watchlist_status` tool — check if a market is being watched (closes #54)
+- `get_conditional_order` tool — get details of a specific conditional order (closes #55)
+- `cancel_conditional_order` tool — cancel a pending conditional order (closes #55)
 
 ## [1.7.1] — 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.7.2] — 2026-04-13
+
+### Added
+- `delete_webhook` tool — delete a registered webhook endpoint (closes #57)
+- `test_webhook` tool — send a test event to verify webhook delivery (closes #57)
+- `list_watchlist` tool — list watched markets with prices and volume (closes #54)
+- `add_to_watchlist` tool — add a market to the watchlist (closes #54)
+- `remove_from_watchlist` tool — remove a market from the watchlist (closes #54)
+- `get_watchlist_status` tool — check if a market is being watched (closes #54)
+
 ## [1.7.1] — 2026-04-13
 
 ### Fixed

--- a/src/index.ts
+++ b/src/index.ts
@@ -449,6 +449,66 @@ const TOOLS = [
     },
   },
   {
+    name: "delete_webhook",
+    description: "Delete a registered webhook endpoint",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        id: { type: "string", description: "Webhook UUID to delete" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "test_webhook",
+    description: "Send a test event payload to a registered webhook to verify delivery",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        id: { type: "string", description: "Webhook UUID to test" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "list_watchlist",
+    description: "List your watched markets with current prices, 24h volume, and price delta",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "add_to_watchlist",
+    description: "Add a market to your watchlist for monitoring",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        marketId: { type: "string", description: "Market UUID to add to watchlist" },
+      },
+      required: ["marketId"],
+    },
+  },
+  {
+    name: "remove_from_watchlist",
+    description: "Remove a market from your watchlist",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        marketId: { type: "string", description: "Market UUID to remove from watchlist" },
+      },
+      required: ["marketId"],
+    },
+  },
+  {
+    name: "get_watchlist_status",
+    description: "Check whether a specific market is on your watchlist",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        marketId: { type: "string", description: "Market UUID to check" },
+      },
+      required: ["marketId"],
+    },
+  },
+  {
     name: "ai_query",
     description: "Ask a natural language question about your account, strategies, portfolio, or market data. The AI interprets your question and returns relevant information.",
     inputSchema: {
@@ -877,6 +937,12 @@ const ROUTES: Record<string, RouteConfig> = {
   list_copy_configs: { method: "GET", path: "/api/v1/copy" },
   list_webhooks: { method: "GET", path: "/api/v1/webhooks" },
   create_webhook: { method: "POST", path: "/api/v1/webhooks", body: (a) => createWebhookSchema.parse(a) },
+  delete_webhook: { method: "DELETE", path: (a) => `/api/v1/webhooks/${encodeURIComponent(String(a.id))}`, schema: idSchema },
+  test_webhook: { method: "POST", path: (a) => `/api/v1/webhooks/${encodeURIComponent(String(a.id))}/test`, schema: idSchema },
+  list_watchlist: { method: "GET", path: "/api/v1/watchlist" },
+  add_to_watchlist: { method: "POST", path: "/api/v1/watchlist", body: (a) => marketIdParamSchema.parse(a) },
+  remove_from_watchlist: { method: "DELETE", path: (a) => `/api/v1/watchlist/${encodeURIComponent(String(a.marketId))}`, schema: marketIdParamSchema },
+  get_watchlist_status: { method: "GET", path: (a) => `/api/v1/watchlist/status/${encodeURIComponent(String(a.marketId))}`, schema: marketIdParamSchema },
   ai_query: { method: "POST", path: "/api/v1/ai/query", body: (a) => aiQuerySchema.parse(a) },
   place_order: { method: "POST", path: "/api/v1/orders/place", body: (a) => placeOrderSchema.parse(a) },
   cancel_order: { method: "DELETE", path: (a) => `/api/v1/orders/${encodeURIComponent(String(a.id))}`, schema: idSchema },

--- a/src/index.ts
+++ b/src/index.ts
@@ -664,6 +664,28 @@ const TOOLS = [
     },
   },
   {
+    name: "get_conditional_order",
+    description: "Get details of a specific conditional order (take-profit, stop-loss, trailing stop, etc.)",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        id: { type: "string", description: "Conditional order UUID" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "cancel_conditional_order",
+    description: "Cancel a pending conditional order",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        id: { type: "string", description: "Conditional order UUID to cancel" },
+      },
+      required: ["id"],
+    },
+  },
+  {
     name: "get_arbitrage_opportunities",
     description: "Scan all active prediction markets for merge arbitrage opportunities — markets where YES + NO prices sum to less than $1.00, locking in risk-free profit on resolution.",
     inputSchema: {
@@ -955,6 +977,8 @@ const ROUTES: Record<string, RouteConfig> = {
   close_position: { method: "POST", path: "/api/v1/orders/close-position", body: (a) => closePositionSchema.parse(a) },
   list_conditional_orders: { method: "GET", path: "/api/v1/orders/conditional", schema: listConditionalOrdersQuerySchema, query: (a) => pickDefined(a, ["status", "type", "limit", "page"]) },
   create_conditional_order: { method: "POST", path: "/api/v1/orders/conditional", body: (a) => createConditionalOrderSchema.parse(a) },
+  get_conditional_order: { method: "GET", path: (a) => `/api/v1/orders/conditional/${encodeURIComponent(String(a.id))}`, schema: idSchema },
+  cancel_conditional_order: { method: "DELETE", path: (a) => `/api/v1/orders/conditional/${encodeURIComponent(String(a.id))}`, schema: idSchema },
   get_arbitrage_opportunities: { method: "GET", path: "/api/v1/arbitrage", schema: arbitrageQuerySchema, query: (a) => pickDefined(a, ["minMargin"]) },
   place_smart_order: { method: "POST", path: "/api/v1/orders/smart", body: (a) => placeSmartOrderSchema.parse(a) },
   list_smart_orders: { method: "GET", path: "/api/v1/orders/smart" },


### PR DESCRIPTION
## Summary

- Added 4 watchlist tools: `list_watchlist`, `add_to_watchlist`, `remove_from_watchlist`, `get_watchlist_status`
- Added 2 webhook mutation tools: `delete_webhook`, `test_webhook`
- Zod validation via existing `idSchema` and `marketIdParamSchema`
- SSRF validation on `create_webhook` already covers new tools (they don't accept URLs)

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Tools appear in `ListToolsRequest` response (6 new tools)
- [ ] Watchlist CRUD works against running PolyForge backend
- [ ] Webhook delete/test works with valid webhook ID

closes #54, closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)