### PR TITLE
fix(security): validate backtest date fields as ISO 8601 format (closes #42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.7.4] — 2026-04-14
+
+### Fixed
+- `run_backtest`: `dateRangeStart` and `dateRangeEnd` now validated as ISO 8601 date format (`YYYY-MM-DD`) instead of accepting arbitrary strings (closes #42)
+
 ## [1.7.3] — 2026-04-14
 
 ### Fixed

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,10 +74,12 @@ const placeOrderSchema = z.object({
   orderType: z.enum(["GTC", "GTD", "FOK"]).optional(),
 });
 
+const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
 const runBacktestSchema = z.object({
   strategyId: z.string().uuid(),
-  dateRangeStart: z.string().optional(),
-  dateRangeEnd: z.string().optional(),
+  dateRangeStart: z.string().regex(isoDateRegex, "Must be ISO 8601 date (YYYY-MM-DD)").optional(),
+  dateRangeEnd: z.string().regex(isoDateRegex, "Must be ISO 8601 date (YYYY-MM-DD)").optional(),
   quickMode: z.boolean().optional(),
   strategyBlocks: z.unknown().optional(),
   marketBindings: z.unknown().optional(),


### PR DESCRIPTION
## Summary
- `dateRangeStart` and `dateRangeEnd` in `runBacktestSchema` now use `.regex(/^\d{4}-\d{2}-\d{2}$/)` instead of bare `.string()`
- Prevents LLM-supplied arbitrary strings ("yesterday", injection payloads) from reaching the API
- Build clean, no breaking changes

closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)