### PR TITLE
fix(security): cap SSE buffer + validate env at startup (closes #44, closes #45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.7.5] — 2026-04-14
+
+### Security
+- **SSE buffer cap**: `pollStrategyEvents` now enforces a 1 MB maximum buffer size — large SSE payloads abort the connection instead of exhausting memory (closes #44)
+- **Startup env validation**: `POLYFORGE_API_KEY` and `POLYFORGE_API_URL` are now read once at module load and validated before `server.connect()`; missing key exits with a clear fatal error instead of failing silently per-call (closes #45)
+
 ## [1.7.4] — 2026-04-14
 
 ### Fixed

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,16 @@ import { z } from "zod";
 import { resolve4, resolve6 } from "node:dns/promises";
 import { isIP } from "node:net";
 
+// ─── Environment constants (validated at startup) ────────────────
+// Read once at module load; startup guard below rejects missing key.
+
+const POLYFORGE_API_URL = process.env.POLYFORGE_API_URL || "https://localhost:3002";
+const POLYFORGE_API_KEY = process.env.POLYFORGE_API_KEY;
+
+// ─── SSE safety constant ────────────────────────────────────────
+// Maximum bytes buffered from an SSE stream before aborting.
+const MAX_SSE_BUFFER_SIZE = 1_048_576; // 1 MB
+
 // ─── Input validation schemas (Zod) ──────────────────────────────
 // Validates all tool inputs before forwarding to the backend API.
 
@@ -1268,37 +1278,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args = {} } = request.params;
 
-  const apiUrl = process.env.POLYFORGE_API_URL || "https://localhost:3002";
-  const isLocalhostFallback = !process.env.POLYFORGE_API_URL;
-
-  if (isLocalhostFallback) {
-    console.error(
-      "[polyforge-mcp] WARNING: POLYFORGE_API_URL is not set — falling back to https://localhost:3002. " +
-      "Production deployments MUST set POLYFORGE_API_URL to the real API endpoint (e.g. https://api.polyforge.app). " +
-      "Using localhost with HTTPS requires a trusted certificate; do NOT set NODE_TLS_REJECT_UNAUTHORIZED=0 as a workaround."
-    );
-  }
-
-  // Validate API URL — reject non-HTTPS for non-localhost hosts
-  const parsedApiUrl = new URL(apiUrl);
-  if (
-    parsedApiUrl.protocol !== "https:" &&
-    parsedApiUrl.hostname !== "localhost" &&
-    parsedApiUrl.hostname !== "127.0.0.1"
-  ) {
-    return {
-      content: [{ type: "text", text: "Error: POLYFORGE_API_URL must use HTTPS for non-localhost hosts." }],
-      isError: true,
-    };
-  }
-  const apiKey = process.env.POLYFORGE_API_KEY;
-
-  if (!apiKey) {
-    return {
-      content: [{ type: "text", text: "Error: POLYFORGE_API_KEY environment variable is not set. Generate an API key in Polyforge Settings > API Keys." }],
-      isError: true,
-    };
-  }
+  const apiUrl = POLYFORGE_API_URL;
+  const apiKey = POLYFORGE_API_KEY!; // validated at startup — guaranteed non-empty
 
   // ── get_strategy_events: SSE polling (collect N events then return) ──────
   if (name === "get_strategy_events") {
@@ -1405,6 +1386,12 @@ async function pollStrategyEvents(
       if (done) break;
 
       buf += decoder.decode(value, { stream: true });
+
+      if (buf.length > MAX_SSE_BUFFER_SIZE) {
+        controller.abort();
+        throw new Error("SSE event exceeded maximum buffer size (1 MB)");
+      }
+
       const lines = buf.split("\n");
       buf = lines.pop() ?? "";
 
@@ -1527,6 +1514,36 @@ async function callApi(
   }
 
   throw new Error("Rate limited: max retries exceeded");
+}
+
+// ─── Startup validation ─────────────────────────────────────────
+
+if (!POLYFORGE_API_KEY) {
+  process.stderr.write(
+    "FATAL: POLYFORGE_API_KEY environment variable is required. " +
+    "Generate an API key in Polyforge Settings > API Keys.\n"
+  );
+  process.exit(1);
+}
+
+const parsedApiUrl = new URL(POLYFORGE_API_URL);
+if (
+  parsedApiUrl.protocol !== "https:" &&
+  parsedApiUrl.hostname !== "localhost" &&
+  parsedApiUrl.hostname !== "127.0.0.1"
+) {
+  process.stderr.write(
+    "FATAL: POLYFORGE_API_URL must use HTTPS for non-localhost hosts.\n"
+  );
+  process.exit(1);
+}
+
+if (!process.env.POLYFORGE_API_URL) {
+  process.stderr.write(
+    "[polyforge-mcp] WARNING: POLYFORGE_API_URL is not set — falling back to https://localhost:3002. " +
+    "Production deployments MUST set POLYFORGE_API_URL to the real API endpoint (e.g. https://api.polyforge.app). " +
+    "Using localhost with HTTPS requires a trusted certificate; do NOT set NODE_TLS_REJECT_UNAUTHORIZED=0 as a workaround.\n"
+  );
 }
 
 // ─── Start ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **#44 — Unbounded SSE buffer**: `pollStrategyEvents` appended decoded SSE chunks to a string buffer with no size limit. A malicious or misconfigured server sending a large payload could exhaust Node.js memory. Now enforces a `MAX_SSE_BUFFER_SIZE` (1 MB) constant — the connection is aborted with a clear error if the buffer exceeds the limit.

- **#45 — Per-call env reads with no startup validation**: `POLYFORGE_API_URL` and `POLYFORGE_API_KEY` were read from `process.env` on every tool invocation, with the missing-key check returning a soft MCP error instead of failing fast. Now both are read once at module load as constants, and the server exits with a `FATAL` message before `server.connect()` if `POLYFORGE_API_KEY` is missing or `POLYFORGE_API_URL` uses a non-HTTPS scheme for non-localhost hosts.

## What changed

- Added `POLYFORGE_API_URL`, `POLYFORGE_API_KEY`, and `MAX_SSE_BUFFER_SIZE` as module-level constants
- Added startup validation block before `server.connect(transport)` with `process.exit(1)` on failure
- Added buffer size check after each SSE chunk decode in `pollStrategyEvents`
- Replaced per-call `process.env` reads in the `CallToolRequestSchema` handler with cached constants
- Updated CHANGELOG.md

## Test plan

- [ ] Start server without `POLYFORGE_API_KEY` — verify FATAL exit
- [ ] Start server with non-HTTPS `POLYFORGE_API_URL` (e.g. `http://example.com`) — verify FATAL exit
- [ ] Start server with valid env — verify normal operation
- [ ] Verify SSE polling still works for normal-sized payloads

closes #44, closes #45