### PR TITLE
fix(security): upgrade hono to 4.12.12+, @hono/node-server to 1.19.13+ (closes #100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.7.6] — 2026-04-15
+
+### Security
+- Upgrade `hono` to 4.12.12+ and `@hono/node-server` to 1.19.13+ via pnpm update — fixes 6 moderate CVEs: cookie validation bypass, IP restriction bypass, path traversal in toSSG, and middleware bypass via repeated slashes (closes #100)
+
 ## [1.7.5] — 2026-04-14
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -44,8 +44,10 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "overrides": {
-    "hono": ">=4.12.12",
-    "@hono/node-server": ">=1.19.13"
+  "pnpm": {
+    "overrides": {
+      "hono": ">=4.12.12",
+      "@hono/node-server": ">=1.19.13"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  hono: '>=4.12.12'
+  '@hono/node-server': '>=1.19.13'
+
 importers:
 
   .:
@@ -28,7 +32,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.12'
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
 
 packages:
 
-  '@hono/node-server@1.19.12':
-    resolution: {integrity: sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==}
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -200,8 +200,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.10:
-    resolution: {integrity: sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==}
+  hono@4.12.12:
+    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -403,13 +403,13 @@ packages:
 
 snapshots:
 
-  '@hono/node-server@1.19.12(hono@4.12.10)':
+  '@hono/node-server@1.19.14(hono@4.12.12)':
     dependencies:
-      hono: 4.12.10
+      hono: 4.12.12
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.12(hono@4.12.10)
+      '@hono/node-server': 1.19.14(hono@4.12.12)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -419,7 +419,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.10
+      hono: 4.12.12
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -613,7 +613,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.10: {}
+  hono@4.12.12: {}
 
   http-errors@2.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Upgrade `hono` from 4.12.10 to 4.12.12+ and `@hono/node-server` from 1.19.12 to 1.19.13+ via `pnpm update`
- Fixes 6 moderate CVEs in transitive deps from `@modelcontextprotocol/sdk`
- `pnpm audit` now returns clean (0 vulnerabilities)
- Build verified: `pnpm build` passes

## CVEs fixed
| Advisory | Description |
|----------|-------------|
| GHSA-26pp-8wgv-hjvm | Cookie name validation bypass in setCookie() |
| GHSA-r5rp-j6wh-rvv4 | Non-breaking space prefix bypass in getCookie() |
| GHSA-xpcf-pg52-r92g | Incorrect IP matching in ipRestriction() for IPv4-mapped IPv6 |
| GHSA-xf4j-xp2r-rqqx | Path traversal in toSSG() |
| GHSA-wmmm-f939-6g9c | Middleware bypass via repeated slashes (hono) |
| GHSA-92pp-h63x-v22m | Middleware bypass via repeated slashes (@hono/node-server) |

closes #100

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm audit` returns 0 vulnerabilities