### PR TITLE
fix(security): UUID validation + Hono 4.12.14 (closes #117-121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.9.1] — 2026-04-17
+
+### Security
+- **Hono 4.12.14** — upgrade `hono` transitive dependency to ≥4.12.14 via pnpm override; fixes GHSA-458j-xx4x-4375 (HTML injection in JSX SSR via class names) (closes #117)
+- **UUID validation — `list_strategy_comments`, `list_strategy_children`, `get_strategy_event_log`** — strategy ID is now validated as UUID via `idSchema` before the path is constructed, preventing arbitrary string injection (closes #118)
+- **UUID validation — `provide_liquidity`** — `marketId` and `tokenId` tightened from `z.string()` to `z.string().uuid()`; restores protection lost in a previous compat fix (closes #119)
+- **UUID validation — `get_price_history`** — `marketId` tightened from `z.string()` to `z.string().uuid()` (closes #120)
+- **batch_requests path allowlist** — `path` field now must match `/api/v1/` prefix and disallows path traversal sequences, preventing MCP tool injection to internal/admin endpoints (closes #121)
+
+### Fixed
+- **Duplicate `updateRiskSettingsSchema` declaration** — removed accidental duplicate that caused a TypeScript compile error
+
 ## [1.8.0] — 2026-04-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "pnpm": {
     "overrides": {
-      "hono": ">=4.12.12",
+      "hono": ">=4.12.14",
       "@hono/node-server": ">=1.19.13"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  hono: '>=4.12.12'
+  hono: '>=4.12.14'
   '@hono/node-server': '>=1.19.13'
 
 importers:
@@ -32,7 +32,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.12'
+      hono: '>=4.12.14'
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -204,8 +204,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -407,13 +407,13 @@ packages:
 
 snapshots:
 
-  '@hono/node-server@1.19.14(hono@4.12.12)':
+  '@hono/node-server@1.19.14(hono@4.12.14)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.14
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.12)
+      '@hono/node-server': 1.19.14(hono@4.12.14)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -423,7 +423,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.12
+      hono: 4.12.14
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -617,7 +617,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.12: {}
+  hono@4.12.14: {}
 
   http-errors@2.0.1:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,8 +162,8 @@ const mergePositionSchema = z.object({
 });
 
 const provideLiquiditySchema = z.object({
-  marketId: z.string(),
-  tokenId: z.string(),
+  marketId: z.string().uuid(),  // #119 — enforce UUID
+  tokenId: z.string().uuid(),   // #119 — enforce UUID
   amountUsdc: z.number().positive(),
   targetSpread: z.number().min(0).max(1).optional(),
 });
@@ -379,10 +379,15 @@ const updateCopyConfigSchema = z.object({
   priceOffset: z.number().optional(),
 });
 
+// #121 — restrict batch paths to user-facing /api/v1/ endpoints only
+const BATCH_PATH_RE = /^\/api\/v1\/[a-zA-Z0-9\-._~!$&'()*+,;=:@]+(?:\/[a-zA-Z0-9\-._~!$&'()*+,;=:@]*)*\/?$/;
+
 const batchRequestItemSchema = z.object({
   id: z.string().min(1).max(100),
   method: z.enum(["GET", "POST", "PATCH", "DELETE"]),
-  path: z.string().min(1).max(500),
+  path: z.string().min(1).max(500)
+    .regex(BATCH_PATH_RE, "Path must be a user-facing /api/v1/ route")
+    .refine((p) => !p.includes(".."), { message: "Path must not contain traversal sequences" }),
   body: z.record(z.string(), z.unknown()).optional(),
 });
 
@@ -393,7 +398,7 @@ const batchRequestsSchema = z.object({
 // ─── POLA-104 compat fix schemas ──────────────────────────────────
 
 const getPriceHistorySchema = z.object({
-  marketId: z.string(),
+  marketId: z.string().uuid(),  // #120 — enforce UUID
   resolution: z.enum(["1m", "1h", "1d"]).optional(),
   from: z.string().max(50).optional(),
   to: z.string().max(50).optional(),
@@ -425,12 +430,6 @@ const createApiKeySchema = z.object({
   name: z.string().min(1).max(100),
   expiresAt: z.string().max(50).optional(),
   scopes: z.array(z.enum(["READ", "WRITE", "TRADE", "STRATEGY", "WEBHOOK"])).optional(),
-});
-
-const updateRiskSettingsSchema = z.object({
-  drawdownEnabled: z.boolean().optional(),
-  drawdownLookbackHours: z.number().int().min(1).max(168).optional(),
-  drawdownThresholdPct: z.number().min(0.01).max(0.99).optional(),
 });
 
 const updateRiskSettingsSchema = z.object({
@@ -1726,16 +1725,16 @@ const ROUTES: Record<string, RouteConfig> = {
   get_price_history: { method: "GET", path: (a) => `/api/v1/markets/${encodeURIComponent(String(a.marketId))}/price-history`, schema: getPriceHistorySchema, query: (a) => pickDefined(a, ["resolution", "from", "to", "limit"]) },
   // Strategy social (#126)
   like_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/like`, schema: idSchema },
-  list_strategy_comments: { method: "GET", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/comments`, query: (a) => pickDefined(a, ["page", "limit"]) },
+  list_strategy_comments: { method: "GET", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/comments`, schema: idSchema, query: (a) => pickDefined(a, ["page", "limit"]) },  // #118
   add_strategy_comment: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/comments`, schema: addStrategyCommentSchema, body: (a) => { const parsed = addStrategyCommentSchema.parse(a); return { content: parsed.content }; } },
   delete_strategy_comment: { method: "DELETE", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/comments/${encodeURIComponent(String(a.commentId))}`, schema: deleteStrategyCommentSchema },
-  list_strategy_children: { method: "GET", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/children`, query: (a) => pickDefined(a, ["page", "limit"]) },
+  list_strategy_children: { method: "GET", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/children`, schema: idSchema, query: (a) => pickDefined(a, ["page", "limit"]) },  // #118
   report_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/report`, schema: reportStrategySchema, body: (a) => { const parsed = reportStrategySchema.parse(a); return { reason: parsed.reason, ...(parsed.description !== undefined && { description: parsed.description }) }; } },
   // Strategy versioning (#126)
   list_strategy_versions: { method: "GET", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/versions`, schema: idSchema },
   rollback_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/versions/${encodeURIComponent(String(a.versionId))}/rollback`, schema: rollbackStrategySchema },
   // Strategy event log (#126)
-  get_strategy_event_log: { method: "GET", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/event-log`, query: (a) => pickDefined(a, ["page", "limit"]) },
+  get_strategy_event_log: { method: "GET", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/event-log`, schema: idSchema, query: (a) => pickDefined(a, ["page", "limit"]) },  // #118
   // API key management (#126)
   list_api_keys: { method: "GET", path: "/api/v1/api-keys" },
   create_api_key: { method: "POST", path: "/api/v1/api-keys", body: (a) => createApiKeySchema.parse(a) },


### PR DESCRIPTION
## Summary

- **#117** — Upgrade `hono` to ≥4.12.14 via `pnpm.overrides` (GHSA-458j-xx4x-4375: HTML injection in JSX SSR via class names)
- **#118** — Add `schema: idSchema` to `list_strategy_comments`, `list_strategy_children`, `get_strategy_event_log` — UUID-validates the strategy `id` at the MCP boundary before the URL path is constructed
- **#119** — `provideLiquiditySchema`: `marketId` and `tokenId` tightened from `z.string()` to `z.string().uuid()` — restores protection regressed by a previous compat fix
- **#120** — `getPriceHistorySchema`: `marketId` tightened from `z.string()` to `z.string().uuid()`
- **#121** — `batchRequestItemSchema`: `path` must now match `BATCH_PATH_RE` (`/api/v1/` prefix, no traversal) — prevents MCP tool injection to internal/admin endpoints

Also removes a pre-existing duplicate `updateRiskSettingsSchema` declaration that broke `tsc`.

## Test plan

- [x] `pnpm build` passes (TypeScript clean)
- [x] `pnpm-lock.yaml` updated — `hono@4.12.14` resolves
- [x] `list_strategy_comments` with non-UUID `id` returns Zod validation error
- [x] `provide_liquidity` with non-UUID `marketId`/`tokenId` returns Zod validation error
- [x] `get_price_history` with non-UUID `marketId` returns Zod validation error
- [x] `batch_requests` with path `/api/admin/users` returns validation error
- [x] `batch_requests` with path `../../etc/passwd` returns validation error
- [x] `batch_requests` with path `/api/v1/strategies` passes

closes #117, closes #118, closes #119, closes #120, closes #121