### PR TITLE
fix(compat): map start_strategy mode to paperMode boolean (closes #144)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -171,6 +171,7 @@ const provideLiquiditySchema = z.object({
 const startStrategySchema = z.object({
   id: z.string().uuid(),
   mode: z.enum(["live", "paper"]).default("paper"),
+  deploymentMode: z.enum(["LIVE", "SIMULATION"]).optional(),
 });
 
 const importBlockSchema = blockSchema.omit({ id: true });
@@ -577,6 +578,7 @@ const TOOLS = [
       properties: {
         id: { type: "string", description: "Strategy UUID" },
         mode: { type: "string", enum: ["live", "paper"], description: "Trading mode — paper is simulated, live places real orders (default: paper)" },
+        deploymentMode: { type: "string", enum: ["LIVE", "SIMULATION"], description: "Optional deployment mode override sent to the platform — SIMULATION for paper, LIVE for real orders" },
       },
       required: ["id"],
     },
@@ -1655,7 +1657,7 @@ const ROUTES: Record<string, RouteConfig> = {
   create_strategy: { method: "POST", path: "/api/v1/strategies", body: (a) => createStrategySchema.parse(a) },
   update_strategy: { method: "PATCH", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}`, body: (a) => { const { id: _id, ...rest } = updateStrategySchema.parse(a); return rest; } },
   create_strategy_from_description: { method: "POST", path: "/api/v1/strategies/from-description", body: (a) => createStrategyFromDescriptionSchema.parse(a) },
-  start_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/start`, schema: startStrategySchema, body: (a) => { const parsed = startStrategySchema.parse(a); return { mode: parsed.mode }; } },
+  start_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/start`, schema: startStrategySchema, body: (a) => { const parsed = startStrategySchema.parse(a); return { paperMode: parsed.mode === "paper", ...(parsed.deploymentMode && { deploymentMode: parsed.deploymentMode }) }; } },
   stop_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/stop`, schema: idSchema },
   get_strategy_templates: { method: "GET", path: "/api/v1/strategies/templates" },
   export_strategy: { method: "GET", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/export`, schema: idSchema },


### PR DESCRIPTION
## Summary

- `start_strategy` was sending `{ mode: "paper" }` but the platform `POST /api/v1/strategies/{id}/start` expects `{ paperMode: boolean, deploymentMode?: "LIVE"|"SIMULATION" }`
- The `mode` field was silently ignored, causing all strategies to run in **live mode** regardless of user intent — real orders were placed even when paper trading was requested
- Fix maps the existing user-facing `mode` enum to `paperMode: boolean` in the body transform, preserving backward compatibility

## Changes

- `startStrategySchema`: added optional `deploymentMode: z.enum(["LIVE", "SIMULATION"])` field
- Route body transform: `mode` → `paperMode: parsed.mode === "paper"` + optional `deploymentMode` passthrough
- Tool `inputSchema`: exposed `deploymentMode` property for AI assistants

## Test plan

- [ ] `start_strategy { id: "...", mode: "paper" }` → sends `{ paperMode: true }` to platform
- [ ] `start_strategy { id: "...", mode: "live" }` → sends `{ paperMode: false }` to platform
- [ ] `start_strategy { id: "...", mode: "paper", deploymentMode: "SIMULATION" }` → sends `{ paperMode: true, deploymentMode: "SIMULATION" }`
- [ ] Omitting `mode` defaults to `"paper"` → sends `{ paperMode: true }`

Fixes #144. Tracked in [POLA-308](/POLA/issues/POLA-308).

🤖 Generated with [Claude Code](https://claude.com/claude-code)