### PR TITLE
fix(security): add max bounds to canvas.connections array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -196,8 +196,10 @@ const importStrategySchema = z.object({
       actions: z.array(importBlockSchema).max(50).optional(),
     }).optional(),
     canvas: z.object({
-      positions: z.record(z.string(), z.object({ x: z.number(), y: z.number() })).optional(),
-      connections: z.array(z.object({ from: z.string(), to: z.string() })).optional(),
+      positions: z.record(z.string().max(100), z.object({ x: z.number(), y: z.number() }))
+        .refine(obj => Object.keys(obj).length <= 200, { message: "Too many positions (max 200)" })
+        .optional(),
+      connections: z.array(z.object({ from: z.string().max(100), to: z.string().max(100) })).max(500).optional(),
     }).optional(),
   }),
 });


### PR DESCRIPTION
## Summary

- Adds `.max(500)` to `canvas.connections` array in `importStrategySchema` to prevent DoS via oversized import payloads
- Adds `.max(100)` to `from`/`to` string fields in connections
- Adds `.refine()` to limit `positions` record to max 200 entries with key strings capped at 100 chars

Closes #148

## Test plan

- [ ] Import a strategy with 500 connections (should succeed)
- [ ] Import a strategy with 501 connections (should reject)
- [ ] Import with connection string >100 chars (should reject)
- [ ] Import with >200 position entries (should reject)

🤖 Generated with [Claude Code](https://claude.com/claude-code)