### PR TITLE
fix(marketplace): add .max(50) inner bound to createMarketplaceListingSchema tags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -352,7 +352,7 @@ const createMarketplaceListingSchema = z.object({
   title: z.string().min(1).max(200),
   priceUsdc: z.number().positive(),
   description: z.string().max(1000).optional(),
-  tags: z.array(z.string()).max(20).optional(),
+  tags: z.array(z.string().max(50)).max(20).optional(),
 });
 
 const updateMarketplaceListingSchema = z.object({


### PR DESCRIPTION
## Summary

- Adds `.max(50)` constraint to inner `z.string()` in `createMarketplaceListingSchema.tags`, matching the existing constraint in `updateMarketplaceListingSchema`
- Prevents unbounded tag strings on marketplace listing creation
- One-line change, typecheck passes clean

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] CI green on push

Closes POLA-368

🤖 Generated with [Claude Code](https://claude.com/claude-code)