### PR TITLE
fix(discover_strategies): correct sort enum to top_pnl/most_forked

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -323,7 +323,7 @@ const browseMarketplaceQuerySchema = z.object({
 // ─── New tool schemas (closes #66) ──────────────────────────────
 
 const discoverStrategiesSchema = z.object({
-  sort: z.enum(["popular", "newest", "returns", "rating"]).optional(),
+  sort: z.enum(["popular", "newest", "top_pnl", "most_forked"]).optional(),
   category: z.string().max(100).optional(),
   search: z.string().max(200).optional(),
   limit: z.coerce.number().int().min(1).max(100).optional(),
@@ -1179,7 +1179,7 @@ const TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        sort: { type: "string", enum: ["popular", "newest", "returns", "rating"], description: "Sort order (default: popular)" },
+        sort: { type: "string", enum: ["popular", "newest", "top_pnl", "most_forked"], description: "Sort order (default: popular)" },
         category: { type: "string", description: "Category filter (e.g. crypto, politics, sports)" },
         search: { type: "string", description: "Search query to filter strategies by title or description" },
         limit: { type: "number", description: "Max results per page (default 20, max 100)" },


### PR DESCRIPTION
## Summary

- Fixed `discover_strategies` sort enum mismatch — replaced stale `returns`/`rating` values with platform-correct `top_pnl`/`most_forked`
- Updated both Zod schema (line 326) and JSON Schema tool definition (line 1182)
- Aligns with TypeScript SDK `src/types.ts:877` and backend `discover.controller.ts:11`

Closes #141

## Test plan

- [ ] CI passes (lint + typecheck + build)
- [ ] Manual: call `discover_strategies` with `sort: "top_pnl"` — should succeed
- [ ] Manual: call with `sort: "returns"` — should fail validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)