### PR TITLE
fix(compat): get_price_history accepts valid Polymarket token IDs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -408,7 +408,7 @@ const batchRequestsSchema = z.object({
 // ─── POLA-104 compat fix schemas ──────────────────────────────────
 
 const getPriceHistorySchema = z.object({
-  marketId: z.string().uuid(),  // #120 — enforce UUID
+  tokenId: z.string().min(1).max(200),
   resolution: z.enum(["1m", "1h", "1d"]).optional(),
   from: z.string().max(50).optional(),
   to: z.string().max(50).optional(),
@@ -1451,13 +1451,13 @@ const TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        marketId: { type: "string", description: "Market condition ID" },
+        tokenId: { type: "string", description: "Polymarket token ID (numeric string or UUID)" },
         resolution: { type: "string", enum: ["1m", "1h", "1d"], description: "Candle resolution (default: 1h)" },
         from: { type: "string", description: "Start date/time in ISO 8601 format (e.g. 2026-01-01T00:00:00Z)" },
         to: { type: "string", description: "End date/time in ISO 8601 format (e.g. 2026-01-31T23:59:59Z)" },
         limit: { type: "number", description: "Max data points to return (default: 100, max: 1000)" },
       },
-      required: ["marketId"],
+      required: ["tokenId"],
     },
   },
 
@@ -1742,7 +1742,7 @@ const ROUTES: Record<string, RouteConfig> = {
   // Backtest Orders (closes #66)
   get_backtest_orders: { method: "GET", path: (a) => `/api/v1/backtests/${encodeURIComponent(String(a.id))}/orders`, schema: idSchema },
   // Price history (#126)
-  get_price_history: { method: "GET", path: (a) => `/api/v1/markets/${encodeURIComponent(String(a.marketId))}/price-history`, schema: getPriceHistorySchema, query: (a) => pickDefined(a, ["resolution", "from", "to", "limit"]) },
+  get_price_history: { method: "GET", path: (a) => `/api/v1/markets/${encodeURIComponent(String(a.tokenId))}/price-history`, schema: getPriceHistorySchema, query: (a) => pickDefined(a, ["resolution", "from", "to", "limit"]) },
   // Strategy social (#126)
   like_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/like`, schema: idSchema },
   list_strategy_comments: { method: "GET", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/comments`, schema: idSchema, query: (a) => pickDefined(a, ["page", "limit"]) },  // #118


### PR DESCRIPTION
## Summary

- Renames `marketId` → `tokenId` in the `get_price_history` tool (Zod schema, MCP tool definition, route handler) to match the backend's `:tokenId` path parameter
- Removes UUID-only validation (`.string().uuid()`) — Polymarket token IDs are large numeric strings, not UUIDs
- Adds `.min(1).max(200)` length bounds for safety

## Context

Polymarket uses **condition IDs** (UUIDs) for markets but **token IDs** (large numeric strings) for individual outcome tokens. The `get_price_history` endpoint operates on tokens, so the previous UUID-only schema rejected every valid token lookup.

Resolves POLA-303 · Closes #151

## Test plan

- [ ] `get_price_history` with a numeric Polymarket token ID (e.g. `21742633143463906290569050155826241533067272736897614950488156847949938836455`)
- [ ] `get_price_history` with a UUID-format token ID still works
- [ ] `pnpm build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)