### PR TITLE
feat(rewards): add 7 Rewards API tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.10.0] — 2026-04-23
+
+### Added
+- **Rewards & Rebates** — `list_rewards_markets`, `get_rewards_for_market`, `get_user_rewards`, `get_user_rewards_total`, `get_user_rewards_percentages`, `get_user_rewards_per_market`, `get_user_rebates` (closes #155)
+
 ## [1.9.4] — 2026-04-21
 
 ### Fixed

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,6 +264,7 @@ const getStrategyEventsSchema = z.object({
 // format at the MCP boundary instead of forwarding arbitrary strings.
 
 const idSchema = z.object({ id: z.string().uuid() });
+const conditionIdSchema = z.object({ conditionId: z.string().min(1) });
 
 const marketIdParamSchema = z.object({ marketId: z.string().uuid() });
 
@@ -1934,6 +1935,66 @@ const TOOLS = [
       },
     },
   },
+  // ── Rewards & Rebates (closes #155) ─────────────────────────────────
+  {
+    name: "list_rewards_markets",
+    description: "List all Polymarket markets that are eligible for liquidity rewards. Returns each market's condition ID, daily reward amount, and reward parameters.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "get_rewards_for_market",
+    description: "Get reward details for a specific market by its Polymarket condition ID. Returns the reward rate, daily payout, and eligibility criteria for that market.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        conditionId: { type: "string", description: "Polymarket condition ID of the market" },
+      },
+      required: ["conditionId"],
+    },
+  },
+  {
+    name: "get_user_rewards",
+    description: "Get the authenticated user's accrued Polymarket liquidity rewards. Returns an array of reward entries with amounts and market details.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "get_user_rewards_total",
+    description: "Get the authenticated user's total accumulated rewards with a breakdown by date. Useful for tracking reward earnings over time.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "get_user_rewards_percentages",
+    description: "Get the authenticated user's reward allocation percentages. Shows the percentage breakdown of rewards across different markets or categories.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "get_user_rewards_per_market",
+    description: "Get the authenticated user's rewards broken down by individual market. Shows how much each market has contributed to total rewards.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "get_user_rebates",
+    description: "Get the authenticated user's Polymarket trading rebates. Returns rebate amounts earned from trading activity.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
 ];
 
 // ─── Route mapping ─────────────────────────────────────────────────
@@ -2078,6 +2139,14 @@ export const ROUTES: Record<string, RouteConfig> = {
   get_polymarket_portfolio: { method: "GET", path: "/api/v1/portfolio/polymarket/portfolio", schema: polymarketPortfolioSchema, query: (a) => pickDefined(a, ["limit", "page"]) },
   get_polymarket_earnings: { method: "GET", path: "/api/v1/portfolio/polymarket/earnings" },
   get_polymarket_activity: { method: "GET", path: "/api/v1/portfolio/polymarket/activity", schema: polymarketActivitySchema, query: (a) => pickDefined(a, ["limit", "page"]) },
+  // Rewards & Rebates (closes #155)
+  list_rewards_markets: { method: "GET", path: "/api/v1/rewards/markets" },
+  get_rewards_for_market: { method: "GET", path: (a) => `/api/v1/rewards/markets/${encodeURIComponent(String(a.conditionId))}`, schema: conditionIdSchema },
+  get_user_rewards: { method: "GET", path: "/api/v1/rewards/user" },
+  get_user_rewards_total: { method: "GET", path: "/api/v1/rewards/user/total" },
+  get_user_rewards_percentages: { method: "GET", path: "/api/v1/rewards/user/percentages" },
+  get_user_rewards_per_market: { method: "GET", path: "/api/v1/rewards/user/markets" },
+  get_user_rebates: { method: "GET", path: "/api/v1/rewards/rebates" },
   // get_strategy_events is handled separately (SSE polling, not a simple REST call)
 };
 


### PR DESCRIPTION
## Summary

- Adds 7 new MCP tools for the Polymarket Rewards API family (closes #155, POLA-299)
- `list_rewards_markets` — browse reward-eligible markets
- `get_rewards_for_market` — reward details for a specific market by condition ID
- `get_user_rewards` — user's accrued liquidity rewards
- `get_user_rewards_total` — total rewards with daily breakdown
- `get_user_rewards_percentages` — reward allocation percentages
- `get_user_rewards_per_market` — rewards breakdown by market
- `get_user_rebates` — user's trading rebates

All endpoints are GET-only. JWT auth is handled by the backend. Input validation via Zod for `conditionId` path parameter.

## Changes

- `src/index.ts`: Added `conditionIdSchema`, 7 TOOLS entries, 7 ROUTES entries
- `CHANGELOG.md`: Version 1.10.0 entry

## Test plan

- [x] TypeScript builds cleanly (`pnpm build`)
- [ ] Manual verification with MCP inspector against running backend
- [ ] CI pipeline (lint, typecheck, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)