### PR TITLE
fix(compat): remove phantom type field from create_marketplace_listing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -350,7 +350,6 @@ const whaleAddressSchema = z.object({
 
 const createMarketplaceListingSchema = z.object({
   strategyId: z.string().uuid(),
-  type: z.enum(["STRATEGY", "SIGNAL", "TEMPLATE"]),
   title: z.string().min(1).max(200),
   priceUsdc: z.number().positive(),
   description: z.string().max(1000).optional(),
@@ -1296,13 +1295,12 @@ const TOOLS = [
       type: "object" as const,
       properties: {
         strategyId: { type: "string", description: "UUID of the strategy to list" },
-        type: { type: "string", enum: ["STRATEGY", "SIGNAL", "TEMPLATE"], description: "Listing type: STRATEGY (automated), SIGNAL (alerts only), or TEMPLATE (non-executable blueprint)" },
         title: { type: "string", description: "Listing title shown to buyers (max 200 chars)" },
         priceUsdc: { type: "number", description: "Listing price in USDC (must be positive)" },
         description: { type: "string", description: "Marketplace description shown to buyers (max 1000 chars, optional)" },
         tags: { type: "array", items: { type: "string" }, description: "Tags for discoverability (max 20, optional)" },
       },
-      required: ["strategyId", "type", "title", "priceUsdc"],
+      required: ["strategyId", "title", "priceUsdc"],
     },
   },
   {


### PR DESCRIPTION
## Summary

- Removes the phantom `type` field from `createMarketplaceListingSchema` (Zod) and the tool's `inputSchema` (JSON Schema)
- The platform's `CreateListingDto` has no `type` field; NestJS rejects it with 400 due to `forbidNonWhitelisted: true`
- Aligns the MCP tool with the TS SDK and Rust SDK implementations

## Context

Closes https://github.com/F4CTE/polyforge-mcp/issues/153
Paperclip: POLA-475

## Test plan

- [ ] `tsc --noEmit` passes (verified locally)
- [ ] CI build passes
- [ ] Manual test: call `create_marketplace_listing` without `type` field — should succeed against platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)