### PR TITLE
fix(compat): get_price_history rejects valid token IDs (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.9.4] — 2026-04-21
+
+### Fixed
+- **#151** `get_price_history`: renamed argument `marketId` → `tokenId` to match platform endpoint `/api/v1/markets/:tokenId/price-history`; relaxed validation from UUID-only to `z.string().min(1)` since Polymarket CLOB token IDs are large decimal strings, not UUIDs; updated MCP inputSchema description accordingly
+
 ## [1.9.3] — 2026-04-20
 
 ### Fixed

--- a/src/index.ts
+++ b/src/index.ts
@@ -407,7 +407,7 @@ const batchRequestsSchema = z.object({
 // ─── POLA-104 compat fix schemas ──────────────────────────────────
 
 const getPriceHistorySchema = z.object({
-  marketId: z.string().uuid(),  // #120 — enforce UUID
+  tokenId: z.string().min(1),
   resolution: z.enum(["1m", "1h", "1d"]).optional(),
   from: z.string().max(50).optional(),
   to: z.string().max(50).optional(),
@@ -1449,13 +1449,13 @@ const TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        marketId: { type: "string", description: "Market condition ID" },
+        tokenId: { type: "string", description: "Polymarket CLOB token ID (numeric string)" },
         resolution: { type: "string", enum: ["1m", "1h", "1d"], description: "Candle resolution (default: 1h)" },
         from: { type: "string", description: "Start date/time in ISO 8601 format (e.g. 2026-01-01T00:00:00Z)" },
         to: { type: "string", description: "End date/time in ISO 8601 format (e.g. 2026-01-31T23:59:59Z)" },
         limit: { type: "number", description: "Max data points to return (default: 100, max: 1000)" },
       },
-      required: ["marketId"],
+      required: ["tokenId"],
     },
   },
 
@@ -1740,7 +1740,7 @@ const ROUTES: Record<string, RouteConfig> = {
   // Backtest Orders (closes #66)
   get_backtest_orders: { method: "GET", path: (a) => `/api/v1/backtests/${encodeURIComponent(String(a.id))}/orders`, schema: idSchema },
   // Price history (#126)
-  get_price_history: { method: "GET", path: (a) => `/api/v1/markets/${encodeURIComponent(String(a.marketId))}/price-history`, schema: getPriceHistorySchema, query: (a) => pickDefined(a, ["resolution", "from", "to", "limit"]) },
+  get_price_history: { method: "GET", path: (a) => `/api/v1/markets/${encodeURIComponent(String(a.tokenId))}/price-history`, schema: getPriceHistorySchema, query: (a) => pickDefined(a, ["resolution", "from", "to", "limit"]) },
   // Strategy social (#126)
   like_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/like`, schema: idSchema },
   list_strategy_comments: { method: "GET", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/comments`, schema: idSchema, query: (a) => pickDefined(a, ["page", "limit"]) },  // #118


### PR DESCRIPTION
## Summary

- Renamed `marketId` → `tokenId` in the `get_price_history` schema, MCP inputSchema, and route path builder to match the platform endpoint `/api/v1/markets/:tokenId/price-history`
- Relaxed validation from `z.string().uuid()` to `z.string().min(1)` — Polymarket CLOB token IDs are large decimal strings (e.g. `71321045679252212594626385532706912750332728571942134274529806265912567729595`), not UUIDs
- Updated MCP tool property description from "Market condition ID" to "Polymarket CLOB token ID (numeric string)"

## Breaking change

Clients using `marketId` as the argument name must switch to `tokenId`. This aligns with `polyforge-sdk-ts` and `polyforge-sdk-python` which already use `tokenId`/`token_id`.

## Test plan

- [ ] TypeScript compilation passes (`tsc --noEmit`)
- [ ] MCP tool accepts a real Polymarket CLOB token ID without validation error
- [ ] Price history data returns correctly for valid token IDs

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>