### PR TITLE
fix(place_order): add missing required marketId field

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ const aiQuerySchema = z.object({
 });
 
 const placeOrderSchema = z.object({
+  marketId: z.string().uuid(),
   tokenId: z.string().uuid(),
   side: z.enum(["BUY", "SELL"]),
   outcome: z.enum(["YES", "NO"]),
@@ -770,6 +771,7 @@ const TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
+        marketId: { type: "string", description: "Market ID (UUID) for the prediction market" },
         tokenId: { type: "string", description: "Token ID to trade (get from market details)" },
         side: { type: "string", enum: ["BUY", "SELL"], description: "Order side" },
         outcome: { type: "string", enum: ["YES", "NO"], description: "Market outcome to trade" },
@@ -777,7 +779,7 @@ const TOOLS = [
         price: { type: "number", description: "Limit price per share (0.001-0.999). Use 0.999 for market buy, 0.001 for market sell." },
         orderType: { type: "string", enum: ["GTC", "FOK", "GTD"], description: "Order type: GTC (good till cancel), FOK (fill or kill / market order), GTD (good till date). Default: GTC" },
       },
-      required: ["tokenId", "side", "outcome", "size", "price"],
+      required: ["marketId", "tokenId", "side", "outcome", "size", "price"],
     },
   },
   {


### PR DESCRIPTION
## Summary

- Added `marketId: z.string().uuid()` to `placeOrderSchema` Zod validation
- Added `marketId` property to the MCP tool's `inputSchema` for LLM discovery
- Added `marketId` to the `required` array in `inputSchema`

The platform requires `marketId` (UUID) on `POST /api/v1/orders/place` but the MCP tool schema omitted it entirely, causing every order placement to fail with 422.

Closes #143

## Test plan

- [ ] Verify `place_order` tool call with valid `marketId` UUID succeeds (no 422)
- [ ] Verify `place_order` without `marketId` is rejected by Zod validation before hitting API
- [ ] Verify MCP tool listing shows `marketId` as required parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)