### PR TITLE
fix(compat): correct discover_strategies sort enum to top_pnl/most_forked (closes #141)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -325,7 +325,7 @@ const browseMarketplaceQuerySchema = z.object({
 // ─── New tool schemas (closes #66) ──────────────────────────────
 
 const discoverStrategiesSchema = z.object({
-  sort: z.enum(["popular", "newest", "returns", "rating"]).optional(),
+  sort: z.enum(["popular", "newest", "top_pnl", "most_forked"]).optional(),
   category: z.string().max(100).optional(),
   search: z.string().max(200).optional(),
   limit: z.coerce.number().int().min(1).max(100).optional(),
@@ -1180,7 +1180,7 @@ const TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        sort: { type: "string", enum: ["popular", "newest", "returns", "rating"], description: "Sort order (default: popular)" },
+        sort: { type: "string", enum: ["popular", "newest", "top_pnl", "most_forked"], description: "Sort order (default: popular)" },
         category: { type: "string", description: "Category filter (e.g. crypto, politics, sports)" },
         search: { type: "string", description: "Search query to filter strategies by title or description" },
         limit: { type: "number", description: "Max results per page (default 20, max 100)" },


### PR DESCRIPTION
## Summary

- Fixes the `discover_strategies` sort enum mismatch vs. the PolyForge platform contract
- Two enum values were wrong: `returns` → `top_pnl`, `rating` → `most_forked`

## Changes

**`src/index.ts`** — two locations updated:

| Location | Before | After |
|---|---|---|
| Line 328 — Zod schema | `["popular", "newest", "returns", "rating"]` | `["popular", "newest", "top_pnl", "most_forked"]` |
| Line 1183 — JSON Schema def | `["popular", "newest", "returns", "rating"]` | `["popular", "newest", "top_pnl", "most_forked"]` |

## Platform contract (authoritative)

- **TypeScript SDK** `src/types.ts:877`: `sort?: 'popular' | 'newest' | 'top_pnl' | 'most_forked'`
- **Backend controller** `discover.controller.ts:11`: `@IsIn(["popular", "newest", "top_pnl", "most_forked"])`

## Impact

Before this fix, calling `discover_strategies` with `sort: "returns"` or `sort: "rating"` sent an unrecognized value to the platform's `@IsIn` validator, causing silent default fallback. Users had no way to sort by PnL or fork count.

## Test plan

- [ ] `sort: "top_pnl"` and `sort: "most_forked"` are accepted by Zod validation
- [ ] MCP tool JSON Schema surfaces correct enum values to LLM clients
- [ ] CI lint + typecheck + build pass