### PR TITLE
chore: enable Dependabot security alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - ci
+    commit-message:
+      prefix: "chore(ci):"


### PR DESCRIPTION
## Summary
- Enabled GitHub vulnerability alerts on polyforge-mcp (was disabled)
- Enabled automated Dependabot security fixes
- Added `.github/dependabot.yml` with weekly scans for `npm` dependencies and `github-actions` updates

## What changed
- **GitHub API**: Turned on vulnerability alerts + automated security fixes
- **dependabot.yml**: Configures weekly Monday scans, labels PRs with `dependencies`/`ci`, prefixes commits with `chore(deps):` / `chore(ci):`

## Test plan
- [x] Verify vulnerability alerts are now enabled (`gh api repos/F4CTE/polyforge-mcp/vulnerability-alerts` returns 204)
- [x] Verify automated security fixes are enabled
- [ ] After merge, confirm Dependabot starts scanning (check Security tab)

Closes POLA-842

🤖 Generated with [Claude Code](https://claude.com/claude-code)