### PR TITLE
feat(mcp): Phase B — CSV exports + quick backtest (POLA-791)

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -22,10 +22,12 @@ describe("ROUTES", () => {
     query?: (a: Record<string, unknown>) => Record<string, string>;
     body?: (a: Record<string, unknown>) => Record<string, unknown>;
   }>;
+  let CSV_EXPORT_PATHS: Record<string, string>;
 
   beforeAll(async () => {
     const mod = await import("./index.js");
     ROUTES = mod.ROUTES;
+    CSV_EXPORT_PATHS = mod.CSV_EXPORT_PATHS;
   });
 
   it("batch_requests body sends 'items' key (not 'requests') to match platform API", () => {
@@ -178,5 +180,118 @@ describe("ROUTES", () => {
     const route = ROUTES.delete_whale_alert_filter;
     expect(route.method).toBe("DELETE");
     expect(route.path).toBe("/api/v1/whales/alerts/filter");
+  });
+
+  // ── POLA-791 Phase B: Orders, Portfolio, News, Backtests ────────────
+
+  const POLA_791_PHASE_B_ROUTE_TOOLS = [
+    "place_batch_orders",
+    "cancel_orders_bulk",
+    "list_news",
+    "get_news_article",
+    "get_polymarket_portfolio",
+    "get_polymarket_earnings",
+    "get_polymarket_activity",
+    "run_backtest_quick",
+  ] as const;
+
+  it.each(POLA_791_PHASE_B_ROUTE_TOOLS)(
+    "%s is registered in ROUTES",
+    (name) => {
+      expect(ROUTES[name]).toBeDefined();
+      expect(ROUTES[name].method).toBeTruthy();
+    },
+  );
+
+  it("run_backtest_quick is POST to /api/v1/backtests/quick", () => {
+    const route = ROUTES.run_backtest_quick;
+    expect(route.method).toBe("POST");
+    expect(route.path).toBe("/api/v1/backtests/quick");
+  });
+
+  it("run_backtest_quick validates and passes body with strategyId", () => {
+    const route = ROUTES.run_backtest_quick;
+    const body = route.body!({
+      strategyId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      dateRangeStart: "2025-01-01",
+      dateRangeEnd: "2025-06-01",
+    });
+    expect(body).toMatchObject({
+      strategyId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      dateRangeStart: "2025-01-01",
+      dateRangeEnd: "2025-06-01",
+    });
+  });
+
+  it("run_backtest_quick rejects non-UUID strategyId", () => {
+    const route = ROUTES.run_backtest_quick;
+    expect(() => route.body!({ strategyId: "not-a-uuid" })).toThrow();
+  });
+
+  it("run_backtest_quick rejects invalid date format", () => {
+    const route = ROUTES.run_backtest_quick;
+    expect(() => route.body!({
+      strategyId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      dateRangeStart: "January 1st",
+    })).toThrow();
+  });
+
+  it("place_batch_orders is POST to /api/v1/orders/batch", () => {
+    const route = ROUTES.place_batch_orders;
+    expect(route.method).toBe("POST");
+    expect(route.path).toBe("/api/v1/orders/batch");
+  });
+
+  it("cancel_orders_bulk is DELETE to /api/v1/orders/bulk", () => {
+    const route = ROUTES.cancel_orders_bulk;
+    expect(route.method).toBe("DELETE");
+    expect(route.path).toBe("/api/v1/orders/bulk");
+  });
+
+  it("list_news passes limit and page as query", () => {
+    const route = ROUTES.list_news;
+    expect(route.method).toBe("GET");
+    expect(route.path).toBe("/api/v1/news");
+    const q = route.query!({ limit: 50, page: 2 });
+    expect(q).toEqual({ limit: "50", page: "2" });
+  });
+
+  it("get_news_article builds path with article id", () => {
+    const route = ROUTES.get_news_article;
+    expect(route.method).toBe("GET");
+    const path = (route.path as (a: Record<string, unknown>) => string)({ id: "article-123" });
+    expect(path).toBe("/api/v1/news/article-123");
+  });
+
+  it("get_polymarket_portfolio passes limit and page as query", () => {
+    const route = ROUTES.get_polymarket_portfolio;
+    expect(route.method).toBe("GET");
+    expect(route.path).toBe("/api/v1/portfolio/polymarket/portfolio");
+    const q = route.query!({ limit: 20, page: 1 });
+    expect(q).toEqual({ limit: "20", page: "1" });
+  });
+
+  it("get_polymarket_earnings is GET with no query", () => {
+    const route = ROUTES.get_polymarket_earnings;
+    expect(route.method).toBe("GET");
+    expect(route.path).toBe("/api/v1/portfolio/polymarket/earnings");
+  });
+
+  it("get_polymarket_activity passes limit and page as query", () => {
+    const route = ROUTES.get_polymarket_activity;
+    expect(route.method).toBe("GET");
+    expect(route.path).toBe("/api/v1/portfolio/polymarket/activity");
+    const q = route.query!({ limit: 30, page: 3 });
+    expect(q).toEqual({ limit: "30", page: "3" });
+  });
+
+  // ── POLA-791: CSV export paths ─────────────────────────────────────
+
+  it("CSV_EXPORT_PATHS maps export_orders_csv", () => {
+    expect(CSV_EXPORT_PATHS.export_orders_csv).toBe("/api/v1/orders/export/csv");
+  });
+
+  it("CSV_EXPORT_PATHS maps export_portfolio_csv", () => {
+    expect(CSV_EXPORT_PATHS.export_portfolio_csv).toBe("/api/v1/portfolio/export/csv");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -563,7 +563,7 @@ const upsertWhaleAlertFilterSchema = z.object({
 });
 
 const server = new Server(
-  { name: "polyforge", version: "1.11.0" },
+  { name: "polyforge", version: "1.12.0" },
   { capabilities: { tools: {} } },
 );
 
@@ -2160,6 +2160,45 @@ const TOOLS = [
       properties: {},
     },
   },
+
+  // POLA-791 Phase B: Orders export, Portfolio export, Backtests quick
+  {
+    name: "export_orders_csv",
+    description: "Export all your orders as a CSV file. Returns raw CSV text suitable for spreadsheet import.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "export_portfolio_csv",
+    description: "Export your portfolio positions as a CSV file. Returns raw CSV text suitable for spreadsheet import.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "run_backtest_quick",
+    description: "Run a quick backtest — faster iteration with reduced fidelity. Same parameters as run_backtest but returns results faster.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        strategyId: { type: "string", description: "Strategy UUID to backtest" },
+        dateRangeStart: { type: "string", description: "Start date (ISO 8601: YYYY-MM-DD)" },
+        dateRangeEnd: { type: "string", description: "End date (ISO 8601: YYYY-MM-DD)" },
+        strategyBlocks: {
+          type: "object",
+          description: "Optional override: strategy block definitions (triggers, conditions, actions, safety, logicBlocks, calcBlocks)",
+        },
+        marketBindings: {
+          type: "object",
+          description: "Optional override: map of slot names to market UUIDs",
+        },
+      },
+      required: ["strategyId"],
+    },
+  },
 ];
 
 // ─── Route mapping ─────────────────────────────────────────────────
@@ -2171,6 +2210,11 @@ interface RouteConfig {
   query?: (args: Record<string, unknown>) => Record<string, string>;
   body?: (args: Record<string, unknown>) => Record<string, unknown>;
 }
+
+export const CSV_EXPORT_PATHS: Record<string, string> = {
+  export_orders_csv: "/api/v1/orders/export/csv",
+  export_portfolio_csv: "/api/v1/portfolio/export/csv",
+};
 
 export const ROUTES: Record<string, RouteConfig> = {
   list_markets: { method: "GET", path: "/api/v1/markets", schema: listMarketsQuerySchema, query: (a) => pickDefined(a, ["search", "category", "sort", "closed", "limit", "page"]) },
@@ -2326,7 +2370,10 @@ export const ROUTES: Record<string, RouteConfig> = {
   get_whale_alert_filter: { method: "GET", path: "/api/v1/whales/alerts/filter" },
   upsert_whale_alert_filter: { method: "PUT", path: "/api/v1/whales/alerts/filter", body: (a) => upsertWhaleAlertFilterSchema.parse(a) },
   delete_whale_alert_filter: { method: "DELETE", path: "/api/v1/whales/alerts/filter" },
+  // POLA-791 Phase B: Quick backtest (CSV exports handled separately)
+  run_backtest_quick: { method: "POST", path: "/api/v1/backtests/quick", schema: runBacktestSchema, body: (a) => runBacktestSchema.parse(a) },
   // get_strategy_events is handled separately (SSE polling, not a simple REST call)
+  // export_orders_csv and export_portfolio_csv are handled separately (CSV response, not JSON)
 };
 
 function pickDefined(obj: Record<string, unknown>, keys: string[]): Record<string, string> {
@@ -2547,6 +2594,35 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
       const result = await pollStrategyEvents(apiUrl, apiKey, String(id), Number(after_timestamp), cap);
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: "text", text: `API error: ${message}` }], isError: true };
+    }
+  }
+
+  // ── CSV export tools: return raw text, not JSON ──────────────────────
+  const csvPaths = CSV_EXPORT_PATHS;
+  if (csvPaths[name]) {
+    await acquireRateLimitToken();
+    try {
+      const res = await fetch(new URL(csvPaths[name], apiUrl).toString(), {
+        method: "GET",
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal: AbortSignal.timeout(30000),
+      });
+      if (!res.ok) {
+        let errMsg: string;
+        try {
+          const body = await res.json() as { message?: unknown; error?: unknown };
+          const field = body.message ?? body.error;
+          errMsg = typeof field === "string" ? field.slice(0, 200) : `Request failed with status ${res.status}`;
+        } catch {
+          errMsg = `Request failed with status ${res.status}`;
+        }
+        return { content: [{ type: "text", text: `API error: ${errMsg}` }], isError: true };
+      }
+      const csv = await res.text();
+      return { content: [{ type: "text", text: csv }] };
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       return { content: [{ type: "text", text: `API error: ${message}` }], isError: true };


### PR DESCRIPTION
## Summary

Completes MCP Phase B ([POLA-791](https://github.com/F4CTE/polyforge-mcp/issues/180)) — 3 remaining P1 trading endpoints.

7/10 Phase B tools were shipped in Phase A (PR #182, now merged). This adds the final 3:
- `export_orders_csv` — GET `/api/v1/orders/export/csv`
- `export_portfolio_csv` — GET `/api/v1/portfolio/export/csv`
- `run_backtest_quick` — POST `/api/v1/backtests/quick`

### Implementation details
- CSV exports use `CSV_EXPORT_PATHS` handler that returns `res.text()` with 30s timeout
- `run_backtest_quick` reuses `runBacktestSchema`, routes to `/backtests/quick`
- Server version bumped to 1.12.0

### Stats
- +192 lines, 49 total tests (all passing), build clean

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)