### PR TITLE
fix: add /v1 prefix to 19 MCP tool routes (closes #194)

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -317,12 +317,12 @@ describe("ROUTES", () => {
 
   it("get_profile builds path with encoded username", () => {
     const path = ROUTES.get_profile.path as (a: Record<string, unknown>) => string;
-    expect(path({ username: "john doe" })).toBe("/api/profile/john%20doe");
+    expect(path({ username: "john doe" })).toBe("/api/v1/profile/john%20doe");
   });
 
   it("toggle_follow builds path with encoded username", () => {
     const path = ROUTES.toggle_follow.path as (a: Record<string, unknown>) => string;
-    expect(path({ username: "alice" })).toBe("/api/profile/alice/follow");
+    expect(path({ username: "alice" })).toBe("/api/v1/profile/alice/follow");
   });
 
   // ── POLA-792: Settings routes ─────────────────────────────────────
@@ -396,7 +396,7 @@ describe("ROUTES", () => {
   it("get_ticket builds path with encoded UUID", () => {
     const path = ROUTES.get_ticket.path as (a: Record<string, unknown>) => string;
     const uuid = "550e8400-e29b-41d4-a716-446655440000";
-    expect(path({ id: uuid })).toBe(`/api/tickets/${uuid}`);
+    expect(path({ id: uuid })).toBe(`/api/v1/tickets/${uuid}`);
   });
 
   it("add_ticket_message strips id from body", () => {
@@ -435,6 +435,27 @@ describe("ROUTES", () => {
   it("get_notification_preferences is a GET with no body", () => {
     expect(ROUTES.get_notification_preferences.method).toBe("GET");
     expect(ROUTES.get_notification_preferences.body).toBeUndefined();
+  });
+
+  // ── Regression: every route must use /api/v1/ or /auth/v1/ prefix ──
+
+  it("all ROUTES paths start with /api/v1/ or /auth/v1/", () => {
+    const ALLOWED_PREFIXES = ["/api/v1/", "/auth/v1/"];
+    const violations: string[] = [];
+
+    for (const [name, route] of Object.entries(ROUTES)) {
+      let resolvedPath: string;
+      if (typeof route.path === "function") {
+        resolvedPath = route.path({ username: "test", id: "test", matchId: "test", slug: "test", marketId: "test" });
+      } else {
+        resolvedPath = route.path;
+      }
+      if (!ALLOWED_PREFIXES.some((prefix) => resolvedPath.startsWith(prefix))) {
+        violations.push(`${name}: ${resolvedPath}`);
+      }
+    }
+
+    expect(violations).toEqual([]);
   });
 
   // ── POLA-792: All new tools exist in ROUTES ───────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -2687,31 +2687,31 @@ export const ROUTES: Record<string, RouteConfig> = {
   // get_strategy_events is handled separately (SSE polling, not a simple REST call)
   // export_orders_csv and export_portfolio_csv are handled separately (CSV response, not JSON)
   // Profile management (POLA-792)
-  update_my_profile: { method: "PATCH", path: "/api/profile/me", body: (a) => updateMyProfileSchema.parse(a) },
-  change_password: { method: "POST", path: "/api/profile/password", body: (a) => changePasswordSchema.parse(a) },
-  update_profile_notifications: { method: "PATCH", path: "/api/profile/notifications", body: (a) => updateProfileNotificationsSchema.parse(a) },
-  get_profile: { method: "GET", path: (a) => `/api/profile/${encodeURIComponent(String(a.username))}`, schema: usernameParamSchema },
-  toggle_follow: { method: "POST", path: (a) => `/api/profile/${encodeURIComponent(String(a.username))}/follow`, schema: usernameParamSchema },
+  update_my_profile: { method: "PATCH", path: "/api/v1/profile/me", body: (a) => updateMyProfileSchema.parse(a) },
+  change_password: { method: "POST", path: "/api/v1/profile/password", body: (a) => changePasswordSchema.parse(a) },
+  update_profile_notifications: { method: "PATCH", path: "/api/v1/profile/notifications", body: (a) => updateProfileNotificationsSchema.parse(a) },
+  get_profile: { method: "GET", path: (a) => `/api/v1/profile/${encodeURIComponent(String(a.username))}`, schema: usernameParamSchema },
+  toggle_follow: { method: "POST", path: (a) => `/api/v1/profile/${encodeURIComponent(String(a.username))}/follow`, schema: usernameParamSchema },
 
   // Settings (POLA-792)
-  update_settings_profile: { method: "PATCH", path: "/api/settings/profile", body: (a) => updateSettingsProfileSchema.parse(a) },
-  get_settings_notifications: { method: "GET", path: "/api/settings/notifications" },
-  update_settings_notifications: { method: "PATCH", path: "/api/settings/notifications", body: (a) => updateSettingsNotificationsSchema.parse(a) },
-  update_settings_password: { method: "PATCH", path: "/api/settings/password", body: (a) => updateSettingsPasswordSchema.parse(a) },
-  get_beta_usage: { method: "GET", path: "/api/settings/beta-usage" },
-  get_gas_usage: { method: "GET", path: "/api/settings/gas" },
+  update_settings_profile: { method: "PATCH", path: "/api/v1/settings/profile", body: (a) => updateSettingsProfileSchema.parse(a) },
+  get_settings_notifications: { method: "GET", path: "/api/v1/settings/notifications" },
+  update_settings_notifications: { method: "PATCH", path: "/api/v1/settings/notifications", body: (a) => updateSettingsNotificationsSchema.parse(a) },
+  update_settings_password: { method: "PATCH", path: "/api/v1/settings/password", body: (a) => updateSettingsPasswordSchema.parse(a) },
+  get_beta_usage: { method: "GET", path: "/api/v1/settings/beta-usage" },
+  get_gas_usage: { method: "GET", path: "/api/v1/settings/gas" },
 
   // Support tickets (POLA-792)
-  create_ticket: { method: "POST", path: "/api/tickets", body: (a) => createTicketSchema.parse(a) },
-  list_tickets: { method: "GET", path: "/api/tickets", schema: listTicketsSchema, query: (a) => pickDefined(a, ["page", "limit"]) },
-  get_ticket: { method: "GET", path: (a) => `/api/tickets/${encodeURIComponent(String(a.id))}`, schema: ticketIdSchema },
-  add_ticket_message: { method: "POST", path: (a) => `/api/tickets/${encodeURIComponent(String(a.id))}/messages`, body: (a) => { const { id: _id, ...rest } = addTicketMessageSchema.parse(a); return rest; } },
+  create_ticket: { method: "POST", path: "/api/v1/tickets", body: (a) => createTicketSchema.parse(a) },
+  list_tickets: { method: "GET", path: "/api/v1/tickets", schema: listTicketsSchema, query: (a) => pickDefined(a, ["page", "limit"]) },
+  get_ticket: { method: "GET", path: (a) => `/api/v1/tickets/${encodeURIComponent(String(a.id))}`, schema: ticketIdSchema },
+  add_ticket_message: { method: "POST", path: (a) => `/api/v1/tickets/${encodeURIComponent(String(a.id))}/messages`, body: (a) => { const { id: _id, ...rest } = addTicketMessageSchema.parse(a); return rest; } },
 
   // Notification & venue preferences (POLA-792)
-  get_notification_preferences: { method: "GET", path: "/api/users/me/notification-preferences" },
-  update_notification_preferences: { method: "PUT", path: "/api/users/me/notification-preferences", body: (a) => updateEventNotificationsSchema.parse(a) },
-  get_venue_preferences: { method: "GET", path: "/api/users/me/venue-preferences" },
-  update_venue_preferences: { method: "PATCH", path: "/api/users/me/venue-preferences", body: (a) => updateVenuePreferencesSchema.parse(a) },
+  get_notification_preferences: { method: "GET", path: "/api/v1/users/me/notification-preferences" },
+  update_notification_preferences: { method: "PUT", path: "/api/v1/users/me/notification-preferences", body: (a) => updateEventNotificationsSchema.parse(a) },
+  get_venue_preferences: { method: "GET", path: "/api/v1/users/me/venue-preferences" },
+  update_venue_preferences: { method: "PATCH", path: "/api/v1/users/me/venue-preferences", body: (a) => updateVenuePreferencesSchema.parse(a) },
 };
 
 function pickDefined(obj: Record<string, unknown>, keys: string[]): Record<string, string> {


### PR DESCRIPTION
## Summary

- Added `/v1` prefix to all 19 MCP tool route definitions (profile, settings, tickets, user preferences) that were causing 100% 404 failure rate
- Fixed 3 existing test assertions that validated the wrong (broken) paths
- Added blanket regression test ensuring every route in the dispatch table starts with `/api/v1/` or `/auth/v1/`

## Problem

The PolyForge api-service uses `app.setGlobalPrefix("api/v1")`, mounting all controllers under `/api/v1/`. The MCP tools for profile, settings, tickets, and user preferences were using `/api/...` (missing `/v1`), so every call returned 404.

## What changed

- `src/index.ts`: 19 route paths updated from `/api/...` to `/api/v1/...`
- `src/index.test.ts`: 3 assertions fixed + 1 new regression test added (total: 95 tests pass)

## Test plan

- [x] All 95 existing tests pass
- [x] New regression test walks the entire ROUTES table and verifies every path starts with `/api/v1/` or `/auth/v1/`
- [x] TypeScript typecheck passes
- [x] Build passes

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)