### PR TITLE
fix: send {mode} instead of {paperMode} in start_strategy (closes #193)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,6 @@ const provideLiquiditySchema = z.object({
 const startStrategySchema = z.object({
   id: z.string().uuid(),
   mode: z.enum(["live", "paper"]).default("paper"),
-  deploymentMode: z.enum(["LIVE", "SIMULATION"]).optional(),
 });
 
 const importBlockSchema = blockSchema.omit({ id: true });
@@ -777,7 +776,6 @@ const TOOLS = [
       properties: {
         id: { type: "string", description: "Strategy UUID" },
         mode: { type: "string", enum: ["live", "paper"], description: "Trading mode — paper is simulated, live places real orders (default: paper)" },
-        deploymentMode: { type: "string", enum: ["LIVE", "SIMULATION"], description: "Optional deployment mode override sent to the platform — SIMULATION for paper, LIVE for real orders" },
       },
       required: ["id"],
     },
@@ -2536,7 +2534,7 @@ export const ROUTES: Record<string, RouteConfig> = {
   create_strategy: { method: "POST", path: "/api/v1/strategies", body: (a) => createStrategySchema.parse(a) },
   update_strategy: { method: "PATCH", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}`, body: (a) => { const { id: _id, ...rest } = updateStrategySchema.parse(a); return rest; } },
   create_strategy_from_description: { method: "POST", path: "/api/v1/strategies/from-description", body: (a) => createStrategyFromDescriptionSchema.parse(a) },
-  start_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/start`, schema: startStrategySchema, body: (a) => { const parsed = startStrategySchema.parse(a); return { paperMode: parsed.mode === "paper", ...(parsed.deploymentMode && { deploymentMode: parsed.deploymentMode }) }; } },
+  start_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/start`, schema: startStrategySchema, body: (a) => { const parsed = startStrategySchema.parse(a); return { mode: parsed.mode }; } },
   stop_strategy: { method: "POST", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/stop`, schema: idSchema },
   get_strategy_templates: { method: "GET", path: "/api/v1/strategies/templates" },
   export_strategy: { method: "GET", path: (a) => `/api/v1/strategies/${encodeURIComponent(String(a.id))}/export`, schema: idSchema },


### PR DESCRIPTION
## Summary

- Removed `paperMode` transform in `start_strategy` route body — now passes `{mode}` directly
- Removed `deploymentMode` from schema and tool inputSchema (not in platform contract)
- Platform contract now expects `{mode: "live"|"paper"}` — the old transform caused 100% failure rate

## Test plan

- [x] TypeScript typecheck passes
- [x] Build succeeds

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)