### PR TITLE
fix: default POLYFORGE_API_URL to api.polyforge.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ For continuous streaming, use the TypeScript, Python, or Rust SDK's `watchStrate
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `POLYFORGE_API_URL` | No | `http://localhost:3002` | Polyforge API base URL |
+| `POLYFORGE_API_URL` | No | `https://api.polyforge.app` | Polyforge API base URL |
 | `POLYFORGE_API_KEY` | Yes | — | API key from Settings > API Keys |
 
 ## Example Usage

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { isIP } from "node:net";
 // ─── Environment constants (validated at startup) ────────────────
 // Read once at module load; startup guard below rejects missing key.
 
-const POLYFORGE_API_URL = process.env.POLYFORGE_API_URL || "https://localhost:3002";
+const POLYFORGE_API_URL = process.env.POLYFORGE_API_URL || "https://api.polyforge.app";
 const POLYFORGE_API_KEY = process.env.POLYFORGE_API_KEY;
 
 // ─── SSE safety constant ────────────────────────────────────────
@@ -3221,9 +3221,8 @@ if (
 
 if (!process.env.POLYFORGE_API_URL) {
   process.stderr.write(
-    "[polyforge-mcp] WARNING: POLYFORGE_API_URL is not set — falling back to https://localhost:3002. " +
-    "Production deployments MUST set POLYFORGE_API_URL to the real API endpoint (e.g. https://api.polyforge.app). " +
-    "Using localhost with HTTPS requires a trusted certificate; do NOT set NODE_TLS_REJECT_UNAUTHORIZED=0 as a workaround.\n"
+    "[polyforge-mcp] INFO: POLYFORGE_API_URL is not set — using default https://api.polyforge.app. " +
+    "Set POLYFORGE_API_URL to override (e.g. for local development).\n"
   );
 }
 


### PR DESCRIPTION
## Summary

- Change default `POLYFORGE_API_URL` from `https://localhost:3002` to `https://api.polyforge.app` in source code
- Downgrade startup fallback message from WARNING to INFO (the default is now the correct production URL)
- Update README.md environment variable table to reflect `https://api.polyforge.app`

Fixes #197 | POLA-1000

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 95/95 pass
- [x] `npm run build` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)