### PR TITLE
fix(security): add size limits to unbounded Zod schemas

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -46,6 +46,26 @@ describe("ROUTES", () => {
     expect(result.items).toEqual(input.requests);
   });
 
+  // ── POLA-1021: #200 — batch request body size limit ────────────────
+
+  it("batch_requests rejects body exceeding 64 KB", () => {
+    const body = ROUTES.batch_requests.body!;
+    expect(() => {
+      body({
+        requests: [
+          {
+            id: "test",
+            method: "POST",
+            path: "/api/v1/markets",
+            body: Object.fromEntries(
+              Array.from({ length: 50 }, (_, i) => [`key${i}`, "x".repeat(2000)])
+            ),
+          },
+        ],
+      });
+    }).toThrow(/64 KB/);
+  });
+
   // ── POLA-790: Cross-venue arbitrage routes ──────────────────────────
 
   const POLA_790_ARBITRAGE_TOOLS = [
@@ -313,6 +333,24 @@ describe("ROUTES", () => {
     const body = ROUTES.update_profile_notifications.body!;
     const result = body({ email: true, sms: false });
     expect(result).toEqual({ email: true, sms: false });
+  });
+
+  // ── POLA-1021: #199 — notification preferences key count cap ───────
+
+  it("update_profile_notifications rejects more than 50 keys", () => {
+    const body = ROUTES.update_profile_notifications.body!;
+    const tooManyKeys = Object.fromEntries(
+      Array.from({ length: 51 }, (_, i) => [`pref${i}`, true])
+    );
+    expect(() => body(tooManyKeys)).toThrow();
+  });
+
+  it("update_profile_notifications accepts exactly 50 keys", () => {
+    const body = ROUTES.update_profile_notifications.body!;
+    const fiftyKeys = Object.fromEntries(
+      Array.from({ length: 50 }, (_, i) => [`pref${i}`, true])
+    );
+    expect(body(fiftyKeys)).toEqual(fiftyKeys);
   });
 
   it("get_profile builds path with encoded username", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,10 @@ const boundedRecord = (maxKeys: number) =>
 const blockSchema = z.object({
   id: z.string().optional(),
   type: z.string().max(100),
-  config: boundedRecord(20).optional(),
+  config: boundedRecord(20).refine(
+    (obj) => JSON.stringify(obj).length <= 16_384,
+    { message: "Block config must not exceed 16 KB" },
+  ).optional(),
 });
 
 const strategyVariableSchema = z.object({
@@ -69,7 +72,10 @@ const createStrategySchema = z.object({
     ).optional(),
     connections: z.array(z.object({ from: z.string().max(100), to: z.string().max(100) })).max(500).optional(),
     viewport: z.object({ x: z.number(), y: z.number(), zoom: z.number().min(0.1).max(10) }).optional(),
-  }).catchall(z.unknown()).refine(
+  }).catchall(z.unknown().refine(
+    (v) => JSON.stringify(v ?? null).length <= 8_192,
+    { message: "Canvas additional property must not exceed 8 KB" },
+  )).refine(
     (obj) => Object.keys(obj).length <= 10,
     { message: "Canvas must have at most 10 top-level keys" },
   ).optional(),
@@ -415,7 +421,10 @@ const batchRequestItemSchema = z.object({
   path: z.string().min(1).max(500)
     .regex(BATCH_PATH_RE, "Path must be a user-facing /api/v1/ route")
     .refine((p) => !p.includes(".."), { message: "Path must not contain traversal sequences" }),
-  body: boundedRecord(50).optional(),
+  body: boundedRecord(50).refine(
+    (obj) => JSON.stringify(obj).length <= 65_536,
+    { message: "Batch request body must not exceed 64 KB" },
+  ).optional(),
 });
 
 const batchRequestsSchema = z.object({
@@ -575,7 +584,10 @@ const changePasswordSchema = z.object({
   newPassword: z.string().min(8).max(128),
 });
 
-const updateProfileNotificationsSchema = z.object({}).catchall(z.boolean());
+const updateProfileNotificationsSchema = z.object({}).catchall(z.boolean()).refine(
+  (obj) => Object.keys(obj).length <= 50,
+  { message: "Notification preferences must have at most 50 keys" },
+);
 
 const usernameParamSchema = z.object({
   username: z.string().min(1).max(100),


### PR DESCRIPTION
## Summary
- **GH #200**: `boundedRecord` used `z.unknown()` values with no byte-size limit. Added JSON.stringify-based size refinements: 64KB for batch request bodies, 16KB for block configs, 8KB for canvas catchall values
- **GH #199**: `updateProfileNotificationsSchema` had unbounded `.catchall(z.boolean())`. Added `.refine()` with 50-key cap

## Test plan
- [x] Verify batch requests with oversized bodies are rejected
- [x] Verify notification preferences with >50 keys are rejected
- [x] Verify normal payloads still pass validation
- [x] `npm test` passes (98 tests, all green)

Closes #199
Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)